### PR TITLE
[0006] Dynamic resource discovery

### DIFF
--- a/cmd/ksearch.go
+++ b/cmd/ksearch.go
@@ -9,7 +9,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -30,34 +29,6 @@ var (
 	version                   = "dev"
 )
 
-var defaultResources = []string{
-	"Pods",
-	"ConfigMaps",
-	"Endpoints",
-	"Events",
-	"LimitRanges",
-	"Namespaces",
-	"PersistentVolumes",
-	"PersistentVolumeClaims",
-	"PodTemplates",
-	"ResourceQuotas",
-	"Secrets",
-	"Services",
-	"ServiceAccounts",
-	"DaemonSets",
-	"Deployments",
-	"ReplicaSets",
-	"StatefulSets",
-}
-
-func effectiveResources(kinds string) []string {
-	if kinds == "" {
-		return append([]string(nil), defaultResources...)
-	}
-
-	return strings.Split(kinds, ",")
-}
-
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:     "ksearch",
@@ -77,8 +48,21 @@ var rootCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		cfg := config.GetConfigOrDie()
+		clientset := kubernetes.NewForConfigOrDie(cfg)
+
+		resources, err := util.Discover(clientset.Discovery(), kinds)
+		if err != nil {
+			cmd.PrintErrln(err)
+			os.Exit(1)
+		}
+
+		resourceOrder := make([]string, len(resources))
+		for i, resource := range resources {
+			resourceOrder[i] = resource.Kind
+		}
+
 		getter := make(chan interface{})
-		resourceOrder := effectiveResources(kinds)
 		key := cache.KeyFor(currentContext, namespace, kinds, resName)
 
 		if !noCache {
@@ -97,12 +81,9 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		cfg := config.GetConfigOrDie()
-		clientset := kubernetes.NewForConfigOrDie(cfg)
+		go util.Getter(namespace, clientset, resources, getter)
 
-		go util.Getter(namespace, clientset, kinds, getter)
-
-		results := make([]cache.SectionEntry, len(resourceOrder))
+		results := make([]cache.SectionEntry, len(resources))
 		var wg sync.WaitGroup
 		index := 0
 		for resource := range getter {

--- a/cmd/ksearch.go
+++ b/cmd/ksearch.go
@@ -81,7 +81,7 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		go util.Getter(namespace, clientset, resources, getter)
+		go util.Getter(namespace, clientset, cfg, resources, getter)
 
 		results := make([]cache.SectionEntry, len(resources))
 		var wg sync.WaitGroup

--- a/cmd/ksearch.go
+++ b/cmd/ksearch.go
@@ -32,11 +32,13 @@ var (
 	currentContextNameFn    = currentContextName
 	readCacheFn             = cache.Read
 	writeCachedSectionsFn   = writeCachedSections
+	writeCacheFn            = cache.Write
 	getConfigOrDieFn        = func() *rest.Config { return config.GetConfigOrDie() }
 	newClientsetForConfigFn = func(cfg *rest.Config) kubernetes.Interface {
 		return kubernetes.NewForConfigOrDie(cfg)
 	}
 	discoverResourcesFn = util.Discover
+	getterFn            = util.Getter
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -85,37 +87,34 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	resourceOrder := make([]string, len(resources))
-	for i, resource := range resources {
-		resourceOrder[i] = resource.Kind
-	}
-
-	getter := make(chan interface{})
-	go util.Getter(namespace, clientset, cfg, resources, getter)
+	getter := make(chan util.FetchResult)
+	go getterFn(namespace, clientset, cfg, resources, getter)
 
 	results := make([]cache.SectionEntry, len(resources))
 	var wg sync.WaitGroup
 	index := 0
-	for resource := range getter {
+	for fetched := range getter {
 		resultIndex := index
 		index++
 
 		wg.Add(1)
-		go func(idx int, renderedResource interface{}) {
+		go func(idx int, fetched util.FetchResult) {
 			defer wg.Done()
 
 			var buffer bytes.Buffer
-			printers.Printer(&buffer, renderedResource, resName)
+			if fetched.Resource != nil {
+				printers.Printer(&buffer, fetched.Resource, resName)
+			}
 			results[idx] = cache.SectionEntry{
-				Kind:   resourceOrder[idx],
+				Kind:   fetched.Kind,
 				Output: buffer.String(),
 			}
-		}(resultIndex, resource)
+		}(resultIndex, fetched)
 	}
 
 	wg.Wait()
 
-	if err := cache.Write(key, cache.CacheMeta{
+	if err := writeCacheFn(key, cache.CacheMeta{
 		Context:    currentContext,
 		Namespace:  namespace,
 		Kinds:      kinds,

--- a/cmd/ksearch.go
+++ b/cmd/ksearch.go
@@ -16,6 +16,7 @@ import (
 	"github.com/arush-sal/ksearch/pkg/printers"
 	"github.com/arush-sal/ksearch/pkg/util"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
@@ -27,6 +28,15 @@ var (
 	cacheTTL                  time.Duration
 	noCache                   bool
 	version                   = "dev"
+
+	currentContextNameFn    = currentContextName
+	readCacheFn             = cache.Read
+	writeCachedSectionsFn   = writeCachedSections
+	getConfigOrDieFn        = func() *rest.Config { return config.GetConfigOrDie() }
+	newClientsetForConfigFn = func(cfg *rest.Config) kubernetes.Interface {
+		return kubernetes.NewForConfigOrDie(cfg)
+	}
+	discoverResourcesFn = util.Discover
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -36,97 +46,96 @@ var rootCmd = &cobra.Command{
 	Version: version,
 	Long:    `ksearch is a command line tool to search for a given pattern in a Kubernetes cluster and will print all of the available resources in a cluster if none is provided`,
 	Run: func(cmd *cobra.Command, args []string) {
-		ttl, err := resolvedCacheTTL(cmd)
-		if err != nil {
+		if err := runRoot(cmd, args); err != nil {
 			cmd.PrintErrln(err)
 			os.Exit(1)
-		}
-
-		currentContext, err := currentContextName()
-		if err != nil {
-			cmd.PrintErrln(err)
-			os.Exit(1)
-		}
-
-		cfg := config.GetConfigOrDie()
-		clientset := kubernetes.NewForConfigOrDie(cfg)
-
-		resources, err := util.Discover(clientset.Discovery(), kinds)
-		if err != nil {
-			cmd.PrintErrln(err)
-			os.Exit(1)
-		}
-
-		resourceOrder := make([]string, len(resources))
-		for i, resource := range resources {
-			resourceOrder[i] = resource.Kind
-		}
-
-		getter := make(chan interface{})
-		key := cache.KeyFor(currentContext, namespace, kinds, resName)
-
-		if !noCache {
-			entry, err := cache.Read(key, ttl)
-			if err != nil {
-				cmd.PrintErrln(err)
-				os.Exit(1)
-			}
-
-			if entry != nil {
-				if err := writeCachedSections(entry.Sections); err != nil {
-					cmd.PrintErrln(err)
-					os.Exit(1)
-				}
-				return
-			}
-		}
-
-		go util.Getter(namespace, clientset, cfg, resources, getter)
-
-		results := make([]cache.SectionEntry, len(resources))
-		var wg sync.WaitGroup
-		index := 0
-		for resource := range getter {
-			resultIndex := index
-			index++
-
-			wg.Add(1)
-			go func(idx int, renderedResource interface{}) {
-				defer wg.Done()
-
-				var buffer bytes.Buffer
-				printers.Printer(&buffer, renderedResource, resName)
-				results[idx] = cache.SectionEntry{
-					Kind:   resourceOrder[idx],
-					Output: buffer.String(),
-				}
-			}(resultIndex, resource)
-		}
-
-		wg.Wait()
-
-		if err := cache.Write(key, cache.CacheMeta{
-			Context:    currentContext,
-			Namespace:  namespace,
-			Kinds:      kinds,
-			Pattern:    resName,
-			TTLSeconds: int(ttl.Seconds()),
-		}, results); err != nil {
-			cmd.PrintErrln(err)
-			os.Exit(1)
-		}
-
-		for _, result := range results {
-			if len(result.Output) == 0 {
-				continue
-			}
-
-			if _, err := os.Stdout.Write([]byte(result.Output)); err != nil {
-				cmd.PrintErrln(err)
-				os.Exit(1)
-			}
 		}
 	},
+}
+
+func runRoot(cmd *cobra.Command, args []string) error {
+	ttl, err := resolvedCacheTTL(cmd)
+	if err != nil {
+		return err
+	}
+
+	currentContext, err := currentContextNameFn()
+	if err != nil {
+		return err
+	}
+
+	key := cache.KeyFor(currentContext, namespace, kinds, resName)
+
+	if !noCache {
+		entry, err := readCacheFn(key, ttl)
+		if err != nil {
+			return err
+		}
+
+		if entry != nil {
+			return writeCachedSectionsFn(entry.Sections)
+		}
+	}
+
+	cfg := getConfigOrDieFn()
+	clientset := newClientsetForConfigFn(cfg)
+
+	resources, err := discoverResourcesFn(clientset.Discovery(), kinds)
+	if err != nil {
+		return err
+	}
+
+	resourceOrder := make([]string, len(resources))
+	for i, resource := range resources {
+		resourceOrder[i] = resource.Kind
+	}
+
+	getter := make(chan interface{})
+	go util.Getter(namespace, clientset, cfg, resources, getter)
+
+	results := make([]cache.SectionEntry, len(resources))
+	var wg sync.WaitGroup
+	index := 0
+	for resource := range getter {
+		resultIndex := index
+		index++
+
+		wg.Add(1)
+		go func(idx int, renderedResource interface{}) {
+			defer wg.Done()
+
+			var buffer bytes.Buffer
+			printers.Printer(&buffer, renderedResource, resName)
+			results[idx] = cache.SectionEntry{
+				Kind:   resourceOrder[idx],
+				Output: buffer.String(),
+			}
+		}(resultIndex, resource)
+	}
+
+	wg.Wait()
+
+	if err := cache.Write(key, cache.CacheMeta{
+		Context:    currentContext,
+		Namespace:  namespace,
+		Kinds:      kinds,
+		Pattern:    resName,
+		TTLSeconds: int(ttl.Seconds()),
+	}, results); err != nil {
+		return err
+	}
+
+	for _, result := range results {
+		if len(result.Output) == 0 {
+			continue
+		}
+
+		if _, err := os.Stdout.Write([]byte(result.Output)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -156,7 +165,8 @@ func initConfig() {
 }
 
 func resolvedCacheTTL(cmd *cobra.Command) (time.Duration, error) {
-	if cmd.Flags().Lookup("cache-ttl").Changed {
+	flag := cmd.Flags().Lookup("cache-ttl")
+	if flag != nil && flag.Changed {
 		return cacheTTL, nil
 	}
 

--- a/cmd/ksearch_test.go
+++ b/cmd/ksearch_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/arush-sal/ksearch/pkg/cache"
+	"github.com/arush-sal/ksearch/pkg/util"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+func TestRunUsesCacheBeforeDiscovery(t *testing.T) {
+	t.Cleanup(func() {
+		currentContextNameFn = currentContextName
+		readCacheFn = cache.Read
+		writeCachedSectionsFn = writeCachedSections
+		getConfigOrDieFn = func() *rest.Config { return config.GetConfigOrDie() }
+		newClientsetForConfigFn = func(cfg *rest.Config) kubernetes.Interface { return kubernetes.NewForConfigOrDie(cfg) }
+		discoverResourcesFn = util.Discover
+	})
+
+	currentContextNameFn = func() (string, error) {
+		return "ctx", nil
+	}
+	readCacheFn = func(key string, ttl time.Duration) (*cache.CacheEntry, error) {
+		return &cache.CacheEntry{
+			Sections: []cache.SectionEntry{{Kind: "Pods", Output: ""}},
+		}, nil
+	}
+	writeCachedSectionsFn = func(sections []cache.SectionEntry) error {
+		return nil
+	}
+	getConfigOrDieFn = func() *rest.Config {
+		t.Fatal("expected cache hit to return before config initialization")
+		return nil
+	}
+	newClientsetForConfigFn = func(cfg *rest.Config) kubernetes.Interface {
+		t.Fatal("expected cache hit to return before clientset creation")
+		return nil
+	}
+	discoverResourcesFn = func(discoveryClient discovery.DiscoveryInterface, kinds string) ([]util.ResourceMeta, error) {
+		t.Fatal("expected cache hit to return before discovery")
+		return nil, nil
+	}
+
+	if err := runRoot(rootCmd, nil); err != nil {
+		t.Fatalf("runRoot returned error: %v", err)
+	}
+}

--- a/cmd/ksearch_test.go
+++ b/cmd/ksearch_test.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/arush-sal/ksearch/pkg/cache"
 	"github.com/arush-sal/ksearch/pkg/util"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
@@ -17,9 +19,11 @@ func TestRunUsesCacheBeforeDiscovery(t *testing.T) {
 		currentContextNameFn = currentContextName
 		readCacheFn = cache.Read
 		writeCachedSectionsFn = writeCachedSections
+		writeCacheFn = cache.Write
 		getConfigOrDieFn = func() *rest.Config { return config.GetConfigOrDie() }
 		newClientsetForConfigFn = func(cfg *rest.Config) kubernetes.Interface { return kubernetes.NewForConfigOrDie(cfg) }
 		discoverResourcesFn = util.Discover
+		getterFn = util.Getter
 	})
 
 	currentContextNameFn = func() (string, error) {
@@ -48,5 +52,64 @@ func TestRunUsesCacheBeforeDiscovery(t *testing.T) {
 
 	if err := runRoot(rootCmd, nil); err != nil {
 		t.Fatalf("runRoot returned error: %v", err)
+	}
+}
+
+func TestRunUsesFetchedKindsForCacheSections(t *testing.T) {
+	t.Cleanup(func() {
+		currentContextNameFn = currentContextName
+		readCacheFn = cache.Read
+		writeCachedSectionsFn = writeCachedSections
+		writeCacheFn = cache.Write
+		getConfigOrDieFn = func() *rest.Config { return config.GetConfigOrDie() }
+		newClientsetForConfigFn = func(cfg *rest.Config) kubernetes.Interface { return kubernetes.NewForConfigOrDie(cfg) }
+		discoverResourcesFn = util.Discover
+		getterFn = util.Getter
+	})
+
+	currentContextNameFn = func() (string, error) {
+		return "ctx", nil
+	}
+	readCacheFn = func(key string, ttl time.Duration) (*cache.CacheEntry, error) {
+		return nil, nil
+	}
+	getConfigOrDieFn = func() *rest.Config {
+		return &rest.Config{}
+	}
+	newClientsetForConfigFn = func(cfg *rest.Config) kubernetes.Interface {
+		return fake.NewSimpleClientset()
+	}
+	discoverResourcesFn = func(discoveryClient discovery.DiscoveryInterface, kinds string) ([]util.ResourceMeta, error) {
+		return []util.ResourceMeta{
+			{Kind: "ConfigMap", Resource: "configmaps", Namespaced: true},
+			{Kind: "Pod", Resource: "pods", Namespaced: true},
+		}, nil
+	}
+	getterFn = func(namespace string, clientset kubernetes.Interface, cfg *rest.Config, resources []util.ResourceMeta, ch chan util.FetchResult) {
+		defer close(ch)
+		ch <- util.FetchResult{Kind: "ConfigMap", Resource: nil}
+		ch <- util.FetchResult{Kind: "Pod", Resource: &v1.PodList{}}
+	}
+
+	var captured []cache.SectionEntry
+	writeCacheFn = func(key string, meta cache.CacheMeta, sections []cache.SectionEntry) error {
+		captured = append([]cache.SectionEntry(nil), sections...)
+		return nil
+	}
+
+	if err := runRoot(rootCmd, nil); err != nil {
+		t.Fatalf("runRoot returned error: %v", err)
+	}
+
+	if len(captured) != 2 {
+		t.Fatalf("expected 2 cache sections, got %d", len(captured))
+	}
+
+	if captured[0].Kind != "ConfigMap" {
+		t.Fatalf("expected first section kind ConfigMap, got %q", captured[0].Kind)
+	}
+
+	if captured[1].Kind != "Pod" {
+		t.Fatalf("expected second section kind Pod, got %q", captured[1].Kind)
 	}
 }

--- a/pkg/printers/printers.go
+++ b/pkg/printers/printers.go
@@ -1,6 +1,7 @@
 package printers
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strings"
@@ -23,247 +24,290 @@ func flushTabWriter(tabWriter *tabwriter.Writer) {
 	_ = tabWriter.Flush()
 }
 
+func writeSectionIfMatched(w io.Writer, title, divider string, render func(*tabwriter.Writer) int) {
+	var body bytes.Buffer
+	tabWriter := tabwriter.NewWriter(&body, 0, 0, 1, ' ', 0)
+	rows := render(tabWriter)
+	if rows == 0 {
+		return
+	}
+
+	flushTabWriter(tabWriter)
+	writef(w, "\n%s\n%s\n", title, divider)
+	_, _ = io.Copy(w, &body)
+}
+
 func printPodDetails(w io.Writer, pods *v1.PodList, pattern string) {
 	if len(pods.Items) > 0 {
-		writef(w, "\nPods\n----\n")
-		tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-		writef(tabWriter, "%v\t%v\t%v\t%v\n", "NAME", "READY", "STATUS", "RESTARTS")
-
-		for _, pod := range pods.Items {
-			if !matchesPattern(pod.Name, pattern) {
-				continue
+		writeSectionIfMatched(w, "Pods", "----", func(tabWriter *tabwriter.Writer) int {
+			rows := 0
+			writef(tabWriter, "%v\t%v\t%v\t%v\n", "NAME", "READY", "STATUS", "RESTARTS")
+			for _, pod := range pods.Items {
+				if !matchesPattern(pod.Name, pattern) {
+					continue
+				}
+				rows++
+				writef(tabWriter, "%v\t%v\t%v\t%v\n", pod.Name, "", pod.Status.Phase, "")
 			}
-
-			writef(tabWriter, "%v\t%v\t%v\t%v\n", pod.Name, "", pod.Status.Phase, "")
-		}
-		flushTabWriter(tabWriter)
+			return rows
+		})
 	}
 }
 func printPodTemplates(w io.Writer, podTemplates *v1.PodTemplateList, pattern string) {
 	if len(podTemplates.Items) > 0 {
-		writef(w, "\nPodTemplates\n--------------\n")
-		tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-		writef(tabWriter, "%v\n", "NAME")
-		for _, podTemplate := range podTemplates.Items {
-			if !matchesPattern(podTemplate.Name, pattern) {
-				continue
+		writeSectionIfMatched(w, "PodTemplates", "--------------", func(tabWriter *tabwriter.Writer) int {
+			rows := 0
+			writef(tabWriter, "%v\n", "NAME")
+			for _, podTemplate := range podTemplates.Items {
+				if !matchesPattern(podTemplate.Name, pattern) {
+					continue
+				}
+				rows++
+				writef(tabWriter, "%v\n", podTemplate.Name)
 			}
-			writef(tabWriter, "%v\n", podTemplate.Name)
-		}
-		flushTabWriter(tabWriter)
+			return rows
+		})
 	}
 }
 func printConfigMaps(w io.Writer, cms *v1.ConfigMapList, pattern string) {
 	if len(cms.Items) > 0 {
-		writef(w, "\nConfigMaps\n--------------\n")
-		tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-		writef(tabWriter, "%v\t%v\t%v\n", "NAME", "DATA", "AGE")
-		for _, configMap := range cms.Items {
-			if !matchesPattern(configMap.Name, pattern) {
-				continue
+		writeSectionIfMatched(w, "ConfigMaps", "--------------", func(tabWriter *tabwriter.Writer) int {
+			rows := 0
+			writef(tabWriter, "%v\t%v\t%v\n", "NAME", "DATA", "AGE")
+			for _, configMap := range cms.Items {
+				if !matchesPattern(configMap.Name, pattern) {
+					continue
+				}
+				rows++
+				writef(tabWriter, "%v\t%v\t%v\n", configMap.Name, len(configMap.Data), "")
 			}
-			writef(tabWriter, "%v\t%v\t%v\n", configMap.Name, len(configMap.Data), "")
-		}
-		flushTabWriter(tabWriter)
+			return rows
+		})
 	}
 }
 func printEndpoints(w io.Writer, endPoints *v1.EndpointsList, pattern string) {
 	if len(endPoints.Items) > 0 {
-		writef(w, "\nEndpoints\n--------------\n")
-		tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-		writef(tabWriter, "%v\t%v\t%v\n", "NAME", "ENDPOINTS", "AGE")
-		for _, endpoint := range endPoints.Items {
-			if !matchesPattern(endpoint.Name, pattern) {
-				continue
+		writeSectionIfMatched(w, "Endpoints", "--------------", func(tabWriter *tabwriter.Writer) int {
+			rows := 0
+			writef(tabWriter, "%v\t%v\t%v\n", "NAME", "ENDPOINTS", "AGE")
+			for _, endpoint := range endPoints.Items {
+				if !matchesPattern(endpoint.Name, pattern) {
+					continue
+				}
+				rows++
+				writef(tabWriter, "%v\t%v\t%v\n", endpoint.Name, "", "")
 			}
-			writef(tabWriter, "%v\t%v\t%v\n", endpoint.Name, "", "")
-		}
-		flushTabWriter(tabWriter)
+			return rows
+		})
 	}
 }
 func printEvents(w io.Writer, events *v1.EventList, pattern string) {
 	if len(events.Items) > 0 {
-		writef(w, "\nEvents\n--------------\n")
-		tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-		writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\n", "NAMESPACE", "LAST SEEN", "TYPE", "REASON", "OBJECT", "MESSAGE")
-		for _, event := range events.Items {
-			if !matchesPattern(event.Name, pattern) {
-				continue
+		writeSectionIfMatched(w, "Events", "--------------", func(tabWriter *tabwriter.Writer) int {
+			rows := 0
+			writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\n", "NAMESPACE", "LAST SEEN", "TYPE", "REASON", "OBJECT", "MESSAGE")
+			for _, event := range events.Items {
+				if !matchesPattern(event.Name, pattern) {
+					continue
+				}
+				rows++
+				writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\n", event.Namespace, "", event.Type, "", event.InvolvedObject.Kind+"/"+event.InvolvedObject.Name, event.Message)
 			}
-			writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\n", event.Namespace, "", event.Type, "", event.InvolvedObject.Kind+"/"+event.InvolvedObject.Name, event.Message)
-		}
-		flushTabWriter(tabWriter)
+			return rows
+		})
 	}
 }
 func printLimitRanges(w io.Writer, limitRanges *v1.LimitRangeList, pattern string) {
 	if len(limitRanges.Items) > 0 {
-		writef(w, "\nLimitRanges\n--------------\n")
-		tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-		writef(tabWriter, "%v\t%v\n", "NAME", "CREATED AT")
-		for _, limitRange := range limitRanges.Items {
-			if !matchesPattern(limitRange.Name, pattern) {
-				continue
+		writeSectionIfMatched(w, "LimitRanges", "--------------", func(tabWriter *tabwriter.Writer) int {
+			rows := 0
+			writef(tabWriter, "%v\t%v\n", "NAME", "CREATED AT")
+			for _, limitRange := range limitRanges.Items {
+				if !matchesPattern(limitRange.Name, pattern) {
+					continue
+				}
+				rows++
+				writef(tabWriter, "%v\t%v\n", limitRange.Name, limitRange.CreationTimestamp)
 			}
-			writef(tabWriter, "%v\t%v\n", limitRange.Name, limitRange.CreationTimestamp)
-		}
-		flushTabWriter(tabWriter)
+			return rows
+		})
 	}
 }
 func printNamespaces(w io.Writer, namespaces *v1.NamespaceList, pattern string) {
 	if len(namespaces.Items) > 0 {
-		writef(w, "\nNamespaces\n--------------\n")
-		tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-		writef(tabWriter, "%v\t%v\t%v\n", "NAME", "STATUS", "AGE")
-		for _, namespace := range namespaces.Items {
-			if !matchesPattern(namespace.Name, pattern) {
-				continue
+		writeSectionIfMatched(w, "Namespaces", "--------------", func(tabWriter *tabwriter.Writer) int {
+			rows := 0
+			writef(tabWriter, "%v\t%v\t%v\n", "NAME", "STATUS", "AGE")
+			for _, namespace := range namespaces.Items {
+				if !matchesPattern(namespace.Name, pattern) {
+					continue
+				}
+				rows++
+				writef(tabWriter, "%v\t%v\t%v\n", namespace.Name, namespace.Status, "")
 			}
-			writef(tabWriter, "%v\t%v\t%v\n", namespace.Name, namespace.Status, "")
-		}
-		flushTabWriter(tabWriter)
+			return rows
+		})
 	}
 }
 func printPVs(w io.Writer, pvs *v1.PersistentVolumeList, pattern string) {
 	if len(pvs.Items) > 0 {
-		writef(w, "\nPersistentVolumes\n--------------\n")
-		tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-		writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "CAPACITY", "ACCESS MODES", "RECLAIM POLICY", "STATUS", "CLAIM", "STORAGECLASS", "REASON", "AGE")
-
-		for _, pv := range pvs.Items {
-			if !matchesPattern(pv.Name, pattern) {
-				continue
+		writeSectionIfMatched(w, "PersistentVolumes", "--------------", func(tabWriter *tabwriter.Writer) int {
+			rows := 0
+			writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "CAPACITY", "ACCESS MODES", "RECLAIM POLICY", "STATUS", "CLAIM", "STORAGECLASS", "REASON", "AGE")
+			for _, pv := range pvs.Items {
+				if !matchesPattern(pv.Name, pattern) {
+					continue
+				}
+				rows++
+				writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", pv.Name, "", pv.Spec.AccessModes, pv.Spec.PersistentVolumeReclaimPolicy, pv.Status, pv.Spec.ClaimRef.Namespace+"/"+pv.Spec.ClaimRef.Name, pv.Spec.StorageClassName, pv.Status.Reason, "")
 			}
-			writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", pv.Name, "", pv.Spec.AccessModes, pv.Spec.PersistentVolumeReclaimPolicy, pv.Status, pv.Spec.ClaimRef.Namespace+"/"+pv.Spec.ClaimRef.Name, pv.Spec.StorageClassName, pv.Status.Reason, "")
-		}
-		flushTabWriter(tabWriter)
+			return rows
+		})
 	}
 }
 func printPVCs(w io.Writer, pvcs *v1.PersistentVolumeClaimList, pattern string) {
 	if len(pvcs.Items) > 0 {
-		writef(w, "\nPersistentVolumeClaims\n--------------\n")
-		tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-		writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "STATUS", "VOLUME", "CAPACITY", "ACCESS MODES", "STORAGECLASS", "AGE")
-		for _, pvc := range pvcs.Items {
-			if !matchesPattern(pvc.Name, pattern) {
-				continue
+		writeSectionIfMatched(w, "PersistentVolumeClaims", "--------------", func(tabWriter *tabwriter.Writer) int {
+			rows := 0
+			writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "STATUS", "VOLUME", "CAPACITY", "ACCESS MODES", "STORAGECLASS", "AGE")
+			for _, pvc := range pvcs.Items {
+				if !matchesPattern(pvc.Name, pattern) {
+					continue
+				}
+				rows++
+				writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n", pvc.Name, pvc.Status, "", pvc.Status.Capacity.Cpu(), pvc.Spec.AccessModes, pvc.Spec.StorageClassName, "")
 			}
-			writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n", pvc.Name, pvc.Status, "", pvc.Status.Capacity.Cpu(), pvc.Spec.AccessModes, pvc.Spec.StorageClassName, "")
-		}
-		flushTabWriter(tabWriter)
+			return rows
+		})
 	}
 }
 
 func printResourceQuotas(w io.Writer, resQuotas *v1.ResourceQuotaList, pattern string) {
 	if len(resQuotas.Items) > 0 {
-		writef(w, "\nResourceQuotas\n--------------\n")
-		tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-		writef(tabWriter, "%v\t%v\n", "NAME", "CREATED AT")
-		for _, resQ := range resQuotas.Items {
-			if !matchesPattern(resQ.Name, pattern) {
-				continue
+		writeSectionIfMatched(w, "ResourceQuotas", "--------------", func(tabWriter *tabwriter.Writer) int {
+			rows := 0
+			writef(tabWriter, "%v\t%v\n", "NAME", "CREATED AT")
+			for _, resQ := range resQuotas.Items {
+				if !matchesPattern(resQ.Name, pattern) {
+					continue
+				}
+				rows++
+				writef(tabWriter, "%v\t%v\n", resQ.Name, resQ.CreationTimestamp)
 			}
-			writef(tabWriter, "%v\t%v\n", resQ.Name, resQ.CreationTimestamp)
-		}
-		flushTabWriter(tabWriter)
+			return rows
+		})
 	}
 }
 func printSecrets(w io.Writer, secrets *v1.SecretList, pattern string) {
 	if len(secrets.Items) > 0 {
-		writef(w, "\nSecrets\n--------------\n")
-		tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-		writef(tabWriter, "%v\t%v\t%v\t%v\n", "NAME", "TYPE", "DATA", "AGE")
-		for _, secret := range secrets.Items {
-			if !matchesPattern(secret.Name, pattern) {
-				continue
+		writeSectionIfMatched(w, "Secrets", "--------------", func(tabWriter *tabwriter.Writer) int {
+			rows := 0
+			writef(tabWriter, "%v\t%v\t%v\t%v\n", "NAME", "TYPE", "DATA", "AGE")
+			for _, secret := range secrets.Items {
+				if !matchesPattern(secret.Name, pattern) {
+					continue
+				}
+				rows++
+				writef(tabWriter, "%v\t%v\t%v\t%v\n", secret.Name, secret.Type, len(secret.Data), "")
 			}
-			writef(tabWriter, "%v\t%v\t%v\t%v\n", secret.Name, secret.Type, len(secret.Data), "")
-		}
-		flushTabWriter(tabWriter)
+			return rows
+		})
 	}
 }
 func printServices(w io.Writer, services *v1.ServiceList, pattern string) {
 	if len(services.Items) > 0 {
-		writef(w, "\nServices\n--------------\n")
-		tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-		writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "TYPE", "CLUSTER-IP", "EXTERNAL-IP", "PORT(S)", "AGE")
-
-		for _, service := range services.Items {
-			if !matchesPattern(service.Name, pattern) {
-				continue
+		writeSectionIfMatched(w, "Services", "--------------", func(tabWriter *tabwriter.Writer) int {
+			rows := 0
+			writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "TYPE", "CLUSTER-IP", "EXTERNAL-IP", "PORT(S)", "AGE")
+			for _, service := range services.Items {
+				if !matchesPattern(service.Name, pattern) {
+					continue
+				}
+				rows++
+				writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\n", service.Name, service.Spec.Type, service.Spec.ClusterIP, service.Spec.ExternalIPs, service.Spec.Ports, "")
 			}
-			writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\n", service.Name, service.Spec.Type, service.Spec.ClusterIP, service.Spec.ExternalIPs, service.Spec.Ports, "")
-		}
-		flushTabWriter(tabWriter)
+			return rows
+		})
 	}
 }
 func printServiceAccounts(w io.Writer, serviceAccs *v1.ServiceAccountList, pattern string) {
 	if len(serviceAccs.Items) > 0 {
-		writef(w, "\nServiceAccounts\n--------------\n")
-		tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-		writef(tabWriter, "%v\t%v\t%v\n", "NAME", "SECRETS", "AGE")
-		for _, serviceAcc := range serviceAccs.Items {
-			if !matchesPattern(serviceAcc.Name, pattern) {
-				continue
+		writeSectionIfMatched(w, "ServiceAccounts", "--------------", func(tabWriter *tabwriter.Writer) int {
+			rows := 0
+			writef(tabWriter, "%v\t%v\t%v\n", "NAME", "SECRETS", "AGE")
+			for _, serviceAcc := range serviceAccs.Items {
+				if !matchesPattern(serviceAcc.Name, pattern) {
+					continue
+				}
+				rows++
+				writef(tabWriter, "%v\t%v\t%v\n", serviceAcc.Name, len(serviceAcc.Secrets), "")
 			}
-			writef(tabWriter, "%v\t%v\t%v\n", serviceAcc.Name, len(serviceAcc.Secrets), "")
-		}
-		flushTabWriter(tabWriter)
+			return rows
+		})
 	}
 }
 func printDaemonSets(w io.Writer, daemonsets *appsv1.DaemonSetList, pattern string) {
 	if len(daemonsets.Items) > 0 {
-		writef(w, "\nDaemonSets\n--------------\n")
-		tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-		writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAMESPACE", "NAME", "DESIRED", "CURRENT", "READY", "UP-TO-DATE", "AVAILABLE", "NODE SELECTOR", "AGE")
-		for _, ds := range daemonsets.Items {
-			if !matchesPattern(ds.Name, pattern) {
-				continue
+		writeSectionIfMatched(w, "DaemonSets", "--------------", func(tabWriter *tabwriter.Writer) int {
+			rows := 0
+			writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAMESPACE", "NAME", "DESIRED", "CURRENT", "READY", "UP-TO-DATE", "AVAILABLE", "NODE SELECTOR", "AGE")
+			for _, ds := range daemonsets.Items {
+				if !matchesPattern(ds.Name, pattern) {
+					continue
+				}
+				rows++
+				writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", ds.Namespace, ds.Name, ds.Status.DesiredNumberScheduled, ds.Status.CurrentNumberScheduled, ds.Status.NumberReady, "", ds.Status.NumberAvailable, ds.Spec.Template.Spec.NodeSelector, "")
 			}
-			writef(tabWriter, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", ds.Namespace, ds.Name, ds.Status.DesiredNumberScheduled, ds.Status.CurrentNumberScheduled, ds.Status.NumberReady, "", ds.Status.NumberAvailable, ds.Spec.Template.Spec.NodeSelector, "")
-		}
-		flushTabWriter(tabWriter)
+			return rows
+		})
 	}
 }
 func printDeployments(w io.Writer, deployments *appsv1.DeploymentList, pattern string) {
 	if len(deployments.Items) > 0 {
-		writef(w, "\nDeployments\n--------------\n")
-		tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-		writef(tabWriter, "%v\t%v\t%v\t%v\t%v\n", "NAME", "READY", "UP-TO-DATE", "AVAILABLE", "AGE")
-		for _, deployment := range deployments.Items {
-			if !matchesPattern(deployment.Name, pattern) {
-				continue
+		writeSectionIfMatched(w, "Deployments", "--------------", func(tabWriter *tabwriter.Writer) int {
+			rows := 0
+			writef(tabWriter, "%v\t%v\t%v\t%v\t%v\n", "NAME", "READY", "UP-TO-DATE", "AVAILABLE", "AGE")
+			for _, deployment := range deployments.Items {
+				if !matchesPattern(deployment.Name, pattern) {
+					continue
+				}
+				rows++
+				writef(tabWriter, "%v\t%v\t%v\t%v\t%v\n", deployment.Name, deployment.Status.ReadyReplicas, "", deployment.Status.AvailableReplicas, "")
 			}
-			writef(tabWriter, "%v\t%v\t%v\t%v\t%v\n", deployment.Name, deployment.Status.ReadyReplicas, "", deployment.Status.AvailableReplicas, "")
-		}
-		flushTabWriter(tabWriter)
+			return rows
+		})
 	}
 }
 func printReplicaSets(w io.Writer, rsets *appsv1.ReplicaSetList, pattern string) {
 	if len(rsets.Items) > 0 {
-		writef(w, "\nReplicaSets\n--------------\n")
-		tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-		writef(tabWriter, "%v\t%v\t%v\t%v\t%v\n", "NAME", "DESIRED", "CURRENT", "READY", "AGE")
-		for _, rs := range rsets.Items {
-			if !matchesPattern(rs.Name, pattern) {
-				continue
+		writeSectionIfMatched(w, "ReplicaSets", "--------------", func(tabWriter *tabwriter.Writer) int {
+			rows := 0
+			writef(tabWriter, "%v\t%v\t%v\t%v\t%v\n", "NAME", "DESIRED", "CURRENT", "READY", "AGE")
+			for _, rs := range rsets.Items {
+				if !matchesPattern(rs.Name, pattern) {
+					continue
+				}
+				rows++
+				writef(tabWriter, "%v\t%v\t%v\t%v\t%v\n", rs.Name, "", "", "", "")
 			}
-			writef(tabWriter, "%v\t%v\t%v\t%v\t%v\n", rs.Name, "", "", "", "")
-		}
-		flushTabWriter(tabWriter)
+			return rows
+		})
 	}
 }
 func printStateFulSets(w io.Writer, ssets *appsv1.StatefulSetList, pattern string) {
 	if len(ssets.Items) > 0 {
-		writef(w, "\nStatefulSets\n--------------\n")
-		tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-		writef(tabWriter, "%v\t%v\t%v\n", "NAME", "READY", "AGE")
-		for _, sset := range ssets.Items {
-			if !matchesPattern(sset.Name, pattern) {
-				continue
+		writeSectionIfMatched(w, "StatefulSets", "--------------", func(tabWriter *tabwriter.Writer) int {
+			rows := 0
+			writef(tabWriter, "%v\t%v\t%v\n", "NAME", "READY", "AGE")
+			for _, sset := range ssets.Items {
+				if !matchesPattern(sset.Name, pattern) {
+					continue
+				}
+				rows++
+				writef(tabWriter, "%v\t%v\t%v\n", sset.Name, sset.Status.ReadyReplicas, "")
 			}
-			writef(tabWriter, "%v\t%v\t%v\n", sset.Name, sset.Status.ReadyReplicas, "")
-		}
-		flushTabWriter(tabWriter)
+			return rows
+		})
 	}
 }
 
@@ -277,16 +321,18 @@ func printUnstructuredList(w io.Writer, resources *unstructured.UnstructuredList
 		kind = "Resources"
 	}
 
-	writef(w, "\n%s\n--------------\n", kind)
-	tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
-	writef(tabWriter, "%v\t%v\n", "NAMESPACE", "NAME")
-	for _, resource := range resources.Items {
-		if !matchesPattern(resource.GetName(), pattern) {
-			continue
+	writeSectionIfMatched(w, kind, "--------------", func(tabWriter *tabwriter.Writer) int {
+		rows := 0
+		writef(tabWriter, "%v\t%v\n", "NAMESPACE", "NAME")
+		for _, resource := range resources.Items {
+			if !matchesPattern(resource.GetName(), pattern) {
+				continue
+			}
+			rows++
+			writef(tabWriter, "%v\t%v\n", resource.GetNamespace(), resource.GetName())
 		}
-		writef(tabWriter, "%v\t%v\n", resource.GetNamespace(), resource.GetName())
-	}
-	flushTabWriter(tabWriter)
+		return rows
+	})
 }
 
 func Printer(w io.Writer, resource interface{}, pattern string) {

--- a/pkg/printers/printers.go
+++ b/pkg/printers/printers.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	v1 "k8s.io/api/core/v1"
-
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func matchesPattern(name, pattern string) bool {
@@ -267,6 +267,28 @@ func printStateFulSets(w io.Writer, ssets *appsv1.StatefulSetList, pattern strin
 	}
 }
 
+func printUnstructuredList(w io.Writer, resources *unstructured.UnstructuredList, pattern string) {
+	if len(resources.Items) == 0 {
+		return
+	}
+
+	kind := resources.GetKind()
+	if kind == "" {
+		kind = "Resources"
+	}
+
+	writef(w, "\n%s\n--------------\n", kind)
+	tabWriter := tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
+	writef(tabWriter, "%v\t%v\n", "NAMESPACE", "NAME")
+	for _, resource := range resources.Items {
+		if !matchesPattern(resource.GetName(), pattern) {
+			continue
+		}
+		writef(tabWriter, "%v\t%v\n", resource.GetNamespace(), resource.GetName())
+	}
+	flushTabWriter(tabWriter)
+}
+
 func Printer(w io.Writer, resource interface{}, pattern string) {
 	switch typedResource := resource.(type) {
 	case *v1.PodList:
@@ -305,5 +327,7 @@ func Printer(w io.Writer, resource interface{}, pattern string) {
 		printReplicaSets(w, typedResource, pattern)
 	case *appsv1.StatefulSetList:
 		printStateFulSets(w, typedResource, pattern)
+	case *unstructured.UnstructuredList:
+		printUnstructuredList(w, typedResource, pattern)
 	}
 }

--- a/pkg/printers/printers_test.go
+++ b/pkg/printers/printers_test.go
@@ -8,6 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestPrintSecrets_NoSensitiveDataInOutput(t *testing.T) {
@@ -116,5 +117,34 @@ func TestMatchesPattern(t *testing.T) {
 				t.Fatalf("matchesPattern(%q, %q) = %v, want %v", testCase.value, testCase.pattern, got, testCase.match)
 			}
 		})
+	}
+}
+
+func TestPrinter_UnstructuredList(t *testing.T) {
+	list := &unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{
+			{
+				Object: map[string]interface{}{
+					"apiVersion": "example.com/v1",
+					"kind":       "Widget",
+					"metadata": map[string]interface{}{
+						"name":      "demo-widget",
+						"namespace": "default",
+					},
+				},
+			},
+		},
+	}
+	list.SetKind("Widget")
+
+	var output bytes.Buffer
+	Printer(&output, list, "demo")
+
+	if !strings.Contains(output.String(), "Widget") {
+		t.Fatalf("expected kind header in output, got %q", output.String())
+	}
+
+	if !strings.Contains(output.String(), "demo-widget") {
+		t.Fatalf("expected resource name in output, got %q", output.String())
 	}
 }

--- a/pkg/printers/printers_test.go
+++ b/pkg/printers/printers_test.go
@@ -83,6 +83,22 @@ func TestPrinter_PatternFilter(t *testing.T) {
 	}
 }
 
+func TestPrinter_PatternFilterSuppressesEmptySection(t *testing.T) {
+	list := &v1.ConfigMapList{
+		Items: []v1.ConfigMap{
+			{ObjectMeta: metav1.ObjectMeta{Name: "nginx-config"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "redis-config"}},
+		},
+	}
+
+	var output bytes.Buffer
+	Printer(&output, list, "stg-pgdb")
+
+	if output.String() != "" {
+		t.Fatalf("expected no output when no rows match pattern, got %q", output.String())
+	}
+}
+
 func TestMatchesPattern(t *testing.T) {
 	testCases := []struct {
 		name    string
@@ -146,5 +162,30 @@ func TestPrinter_UnstructuredList(t *testing.T) {
 
 	if !strings.Contains(output.String(), "demo-widget") {
 		t.Fatalf("expected resource name in output, got %q", output.String())
+	}
+}
+
+func TestPrinter_UnstructuredListSuppressesEmptySection(t *testing.T) {
+	list := &unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{
+			{
+				Object: map[string]interface{}{
+					"apiVersion": "example.com/v1",
+					"kind":       "Widget",
+					"metadata": map[string]interface{}{
+						"name":      "demo-widget",
+						"namespace": "default",
+					},
+				},
+			},
+		},
+	}
+	list.SetKind("Widget")
+
+	var output bytes.Buffer
+	Printer(&output, list, "stg-pgdb")
+
+	if output.String() != "" {
+		t.Fatalf("expected no output when no unstructured rows match pattern, got %q", output.String())
 	}
 }

--- a/pkg/util/discover.go
+++ b/pkg/util/discover.go
@@ -25,6 +25,7 @@ func Discover(dc discovery.DiscoveryInterface, kinds string) ([]ResourceMeta, er
 
 	filter := parseKindsFilter(kinds)
 	resources := make([]ResourceMeta, 0)
+	seen := make(map[string]bool)
 	for _, list := range lists {
 		if list == nil {
 			continue
@@ -39,12 +40,15 @@ func Discover(dc discovery.DiscoveryInterface, kinds string) ([]ResourceMeta, er
 			if !hasVerb(resource.Verbs, "list") {
 				continue
 			}
-			if _, ok := canonicalResourceName(resource.Kind, resource.Name); !ok {
-				continue
-			}
 			if !matchesKindsFilter(filter, resource.Kind, resource.Name) {
 				continue
 			}
+
+			logicalKey := fmt.Sprintf("%s/%s/%t", gv.Group, resource.Name, resource.Namespaced)
+			if seen[logicalKey] {
+				continue
+			}
+			seen[logicalKey] = true
 
 			resources = append(resources, ResourceMeta{
 				Kind:       resource.Kind,
@@ -94,80 +98,80 @@ func matchesKindsFilter(filter map[string]bool, kind, resource string) bool {
 	return filter[strings.ToLower(kind)] || filter[strings.ToLower(resource)]
 }
 
-func canonicalResourceName(kind, resource string) (string, bool) {
+func canonicalResourceName(kind, resource string) string {
 	switch strings.ToLower(strings.TrimSpace(resource)) {
 	case "pods":
-		return "pods", true
+		return "pods"
 	case "configmaps":
-		return "configmaps", true
+		return "configmaps"
 	case "endpoints":
-		return "endpoints", true
+		return "endpoints"
 	case "events":
-		return "events", true
+		return "events"
 	case "limitranges":
-		return "limitranges", true
+		return "limitranges"
 	case "namespaces":
-		return "namespaces", true
+		return "namespaces"
 	case "persistentvolumes":
-		return "persistentvolumes", true
+		return "persistentvolumes"
 	case "persistentvolumeclaims":
-		return "persistentvolumeclaims", true
+		return "persistentvolumeclaims"
 	case "podtemplates":
-		return "podtemplates", true
+		return "podtemplates"
 	case "resourcequotas":
-		return "resourcequotas", true
+		return "resourcequotas"
 	case "secrets":
-		return "secrets", true
+		return "secrets"
 	case "services":
-		return "services", true
+		return "services"
 	case "serviceaccounts":
-		return "serviceaccounts", true
+		return "serviceaccounts"
 	case "daemonsets":
-		return "daemonsets", true
+		return "daemonsets"
 	case "deployments":
-		return "deployments", true
+		return "deployments"
 	case "replicasets":
-		return "replicasets", true
+		return "replicasets"
 	case "statefulsets":
-		return "statefulsets", true
+		return "statefulsets"
 	}
 
 	switch strings.ToLower(strings.TrimSpace(kind)) {
 	case "pod", "pods":
-		return "pods", true
+		return "pods"
 	case "configmap", "configmaps":
-		return "configmaps", true
+		return "configmaps"
 	case "endpoint", "endpoints":
-		return "endpoints", true
+		return "endpoints"
 	case "event", "events":
-		return "events", true
+		return "events"
 	case "limitrange", "limitranges":
-		return "limitranges", true
+		return "limitranges"
 	case "namespace", "namespaces":
-		return "namespaces", true
+		return "namespaces"
 	case "persistentvolume", "persistentvolumes":
-		return "persistentvolumes", true
+		return "persistentvolumes"
 	case "persistentvolumeclaim", "persistentvolumeclaims":
-		return "persistentvolumeclaims", true
+		return "persistentvolumeclaims"
 	case "podtemplate", "podtemplates":
-		return "podtemplates", true
+		return "podtemplates"
 	case "resourcequota", "resourcequotas":
-		return "resourcequotas", true
+		return "resourcequotas"
 	case "secret", "secrets":
-		return "secrets", true
+		return "secrets"
 	case "service", "services":
-		return "services", true
+		return "services"
 	case "serviceaccount", "serviceaccounts":
-		return "serviceaccounts", true
+		return "serviceaccounts"
 	case "daemonset", "daemonsets":
-		return "daemonsets", true
+		return "daemonsets"
 	case "deployment", "deployments":
-		return "deployments", true
+		return "deployments"
 	case "replicaset", "replicasets":
-		return "replicasets", true
+		return "replicasets"
 	case "statefulset", "statefulsets":
-		return "statefulsets", true
+		return "statefulsets"
 	}
 
-	return "", false
+	return ""
 }

--- a/pkg/util/discover.go
+++ b/pkg/util/discover.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 )
@@ -15,7 +16,7 @@ type ResourceMeta struct {
 }
 
 func Discover(dc discovery.DiscoveryInterface, kinds string) ([]ResourceMeta, error) {
-	_, lists, err := dc.ServerGroupsAndResources()
+	groups, lists, err := dc.ServerGroupsAndResources()
 	if err != nil && lists == nil {
 		return nil, err
 	}
@@ -25,7 +26,8 @@ func Discover(dc discovery.DiscoveryInterface, kinds string) ([]ResourceMeta, er
 
 	filter := parseKindsFilter(kinds)
 	resources := make([]ResourceMeta, 0)
-	seen := make(map[string]bool)
+	indexByKey := make(map[string]int)
+	preferredVersions := preferredVersionByGroup(groups)
 	for _, list := range lists {
 		if list == nil {
 			continue
@@ -44,19 +46,24 @@ func Discover(dc discovery.DiscoveryInterface, kinds string) ([]ResourceMeta, er
 				continue
 			}
 
-			logicalKey := discoveryDedupKey(resource.Kind, resource.Name, gv.Group, resource.Namespaced)
-			if seen[logicalKey] {
-				continue
-			}
-			seen[logicalKey] = true
-
-			resources = append(resources, ResourceMeta{
+			meta := ResourceMeta{
 				Kind:       resource.Kind,
 				Resource:   resource.Name,
 				APIGroup:   gv.Group,
 				APIVersion: gv.Version,
 				Namespaced: resource.Namespaced,
-			})
+			}
+
+			logicalKey := discoveryDedupKey(meta)
+			if idx, ok := indexByKey[logicalKey]; ok {
+				if shouldReplaceDiscoveredResource(meta, resources[idx], preferredVersions) {
+					resources[idx] = meta
+				}
+				continue
+			}
+
+			indexByKey[logicalKey] = len(resources)
+			resources = append(resources, meta)
 		}
 	}
 
@@ -176,10 +183,59 @@ func canonicalResourceName(kind, resource string) string {
 	return ""
 }
 
-func discoveryDedupKey(kind, resource, group string, namespaced bool) string {
-	if canonical := canonicalResourceName(kind, resource); canonical != "" {
-		return fmt.Sprintf("canonical/%s/%t", canonical, namespaced)
+func discoveryDedupKey(meta ResourceMeta) string {
+	if canonical := canonicalResourceName(meta.Kind, meta.Resource); canonical != "" {
+		return fmt.Sprintf("canonical/%s/%t", canonical, meta.Namespaced)
 	}
 
-	return fmt.Sprintf("%s/%s/%t", group, resource, namespaced)
+	return fmt.Sprintf("%s/%s/%t", meta.APIGroup, meta.Resource, meta.Namespaced)
+}
+
+func preferredVersionByGroup(groups []*metav1.APIGroup) map[string]string {
+	preferred := make(map[string]string)
+	for _, group := range groups {
+		if group == nil {
+			continue
+		}
+
+		if group.PreferredVersion.Version != "" {
+			preferred[group.Name] = group.PreferredVersion.Version
+		}
+	}
+	return preferred
+}
+
+func shouldReplaceDiscoveredResource(candidate, existing ResourceMeta, preferredVersions map[string]string) bool {
+	return resourcePriority(candidate, preferredVersions) > resourcePriority(existing, preferredVersions)
+}
+
+func resourcePriority(meta ResourceMeta, preferredVersions map[string]string) int {
+	score := 0
+	if canonical := canonicalResourceName(meta.Kind, meta.Resource); canonical != "" && endpointMatchesTyped(meta, canonical) {
+		score += 4
+	}
+	if preferredVersions[meta.APIGroup] == meta.APIVersion {
+		score += 2
+	}
+	return score
+}
+
+func endpointMatchesTyped(meta ResourceMeta, canonical string) bool {
+	group, version, ok := typedEndpointForCanonical(canonical)
+	if !ok {
+		return false
+	}
+
+	return meta.APIGroup == group && meta.APIVersion == version
+}
+
+func typedEndpointForCanonical(canonical string) (string, string, bool) {
+	switch canonical {
+	case "pods", "configmaps", "endpoints", "events", "limitranges", "namespaces", "persistentvolumes", "persistentvolumeclaims", "podtemplates", "resourcequotas", "secrets", "services", "serviceaccounts":
+		return "", "v1", true
+	case "daemonsets", "deployments", "replicasets", "statefulsets":
+		return "apps", "v1", true
+	default:
+		return "", "", false
+	}
 }

--- a/pkg/util/discover.go
+++ b/pkg/util/discover.go
@@ -1,0 +1,84 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+)
+
+type ResourceMeta struct {
+	Kind, Resource, APIGroup, APIVersion string
+	Namespaced                           bool
+}
+
+func Discover(dc discovery.DiscoveryInterface, kinds string) ([]ResourceMeta, error) {
+	_, lists, err := dc.ServerGroupsAndResources()
+	if err != nil && lists == nil {
+		return nil, err
+	}
+	if err != nil && lists != nil {
+		log.Warnf("partial discovery failure: %v", err)
+	}
+
+	filter := parseKindsFilter(kinds)
+	resources := make([]ResourceMeta, 0)
+	for _, list := range lists {
+		if list == nil {
+			continue
+		}
+
+		gv, parseErr := schema.ParseGroupVersion(list.GroupVersion)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse group version %q: %w", list.GroupVersion, parseErr)
+		}
+
+		for _, resource := range list.APIResources {
+			if !hasVerb(resource.Verbs, "list") {
+				continue
+			}
+			if len(filter) > 0 && !filter[strings.ToLower(resource.Kind)] {
+				continue
+			}
+
+			resources = append(resources, ResourceMeta{
+				Kind:       resource.Kind,
+				Resource:   resource.Name,
+				APIGroup:   gv.Group,
+				APIVersion: gv.Version,
+				Namespaced: resource.Namespaced,
+			})
+		}
+	}
+
+	return resources, nil
+}
+
+func parseKindsFilter(kinds string) map[string]bool {
+	filter := make(map[string]bool)
+	if strings.TrimSpace(kinds) == "" {
+		return filter
+	}
+
+	for _, kind := range strings.Split(kinds, ",") {
+		kind = strings.ToLower(strings.TrimSpace(kind))
+		if kind == "" {
+			continue
+		}
+		filter[kind] = true
+	}
+
+	return filter
+}
+
+func hasVerb(verbs []string, target string) bool {
+	for _, verb := range verbs {
+		if strings.EqualFold(verb, target) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/util/discover.go
+++ b/pkg/util/discover.go
@@ -44,7 +44,7 @@ func Discover(dc discovery.DiscoveryInterface, kinds string) ([]ResourceMeta, er
 				continue
 			}
 
-			logicalKey := fmt.Sprintf("%s/%s/%t", gv.Group, resource.Name, resource.Namespaced)
+			logicalKey := discoveryDedupKey(resource.Kind, resource.Name, gv.Group, resource.Namespaced)
 			if seen[logicalKey] {
 				continue
 			}
@@ -174,4 +174,12 @@ func canonicalResourceName(kind, resource string) string {
 	}
 
 	return ""
+}
+
+func discoveryDedupKey(kind, resource, group string, namespaced bool) string {
+	if canonical := canonicalResourceName(kind, resource); canonical != "" {
+		return fmt.Sprintf("canonical/%s/%t", canonical, namespaced)
+	}
+
+	return fmt.Sprintf("%s/%s/%t", group, resource, namespaced)
 }

--- a/pkg/util/discover.go
+++ b/pkg/util/discover.go
@@ -39,7 +39,10 @@ func Discover(dc discovery.DiscoveryInterface, kinds string) ([]ResourceMeta, er
 			if !hasVerb(resource.Verbs, "list") {
 				continue
 			}
-			if len(filter) > 0 && !filter[strings.ToLower(resource.Kind)] {
+			if _, ok := canonicalResourceName(resource.Kind, resource.Name); !ok {
+				continue
+			}
+			if !matchesKindsFilter(filter, resource.Kind, resource.Name) {
 				continue
 			}
 
@@ -81,4 +84,90 @@ func hasVerb(verbs []string, target string) bool {
 	}
 
 	return false
+}
+
+func matchesKindsFilter(filter map[string]bool, kind, resource string) bool {
+	if len(filter) == 0 {
+		return true
+	}
+
+	return filter[strings.ToLower(kind)] || filter[strings.ToLower(resource)]
+}
+
+func canonicalResourceName(kind, resource string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(resource)) {
+	case "pods":
+		return "pods", true
+	case "configmaps":
+		return "configmaps", true
+	case "endpoints":
+		return "endpoints", true
+	case "events":
+		return "events", true
+	case "limitranges":
+		return "limitranges", true
+	case "namespaces":
+		return "namespaces", true
+	case "persistentvolumes":
+		return "persistentvolumes", true
+	case "persistentvolumeclaims":
+		return "persistentvolumeclaims", true
+	case "podtemplates":
+		return "podtemplates", true
+	case "resourcequotas":
+		return "resourcequotas", true
+	case "secrets":
+		return "secrets", true
+	case "services":
+		return "services", true
+	case "serviceaccounts":
+		return "serviceaccounts", true
+	case "daemonsets":
+		return "daemonsets", true
+	case "deployments":
+		return "deployments", true
+	case "replicasets":
+		return "replicasets", true
+	case "statefulsets":
+		return "statefulsets", true
+	}
+
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "pod", "pods":
+		return "pods", true
+	case "configmap", "configmaps":
+		return "configmaps", true
+	case "endpoint", "endpoints":
+		return "endpoints", true
+	case "event", "events":
+		return "events", true
+	case "limitrange", "limitranges":
+		return "limitranges", true
+	case "namespace", "namespaces":
+		return "namespaces", true
+	case "persistentvolume", "persistentvolumes":
+		return "persistentvolumes", true
+	case "persistentvolumeclaim", "persistentvolumeclaims":
+		return "persistentvolumeclaims", true
+	case "podtemplate", "podtemplates":
+		return "podtemplates", true
+	case "resourcequota", "resourcequotas":
+		return "resourcequotas", true
+	case "secret", "secrets":
+		return "secrets", true
+	case "service", "services":
+		return "services", true
+	case "serviceaccount", "serviceaccounts":
+		return "serviceaccounts", true
+	case "daemonset", "daemonsets":
+		return "daemonsets", true
+	case "deployment", "deployments":
+		return "deployments", true
+	case "replicaset", "replicasets":
+		return "replicasets", true
+	case "statefulset", "statefulsets":
+		return "statefulsets", true
+	}
+
+	return "", false
 }

--- a/pkg/util/discover_test.go
+++ b/pkg/util/discover_test.go
@@ -1,0 +1,130 @@
+package util
+
+import (
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestDiscover_AllWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	resources, err := Discover(newFakeDiscovery(), "")
+	if err != nil {
+		t.Fatalf("Discover returned error: %v", err)
+	}
+
+	if len(resources) != 3 {
+		t.Fatalf("expected 3 listable resources, got %d", len(resources))
+	}
+}
+
+func TestDiscover_FilterByKinds(t *testing.T) {
+	t.Parallel()
+
+	resources, err := Discover(newFakeDiscovery(), "ConfigMaps")
+	if err != nil {
+		t.Fatalf("Discover returned error: %v", err)
+	}
+
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+
+	if resources[0].Kind != "ConfigMaps" {
+		t.Fatalf("expected ConfigMaps, got %q", resources[0].Kind)
+	}
+}
+
+func TestDiscover_SkipsNonListable(t *testing.T) {
+	t.Parallel()
+
+	resources, err := Discover(newFakeDiscovery(), "")
+	if err != nil {
+		t.Fatalf("Discover returned error: %v", err)
+	}
+
+	for _, resource := range resources {
+		if resource.Kind == "Widgets" {
+			t.Fatalf("expected non-listable resource to be skipped: %#v", resource)
+		}
+	}
+}
+
+func TestDiscover_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	resources, err := Discover(newFakeDiscovery(), "configmaps")
+	if err != nil {
+		t.Fatalf("Discover returned error: %v", err)
+	}
+
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(resources))
+	}
+
+	if resources[0].Kind != "ConfigMaps" {
+		t.Fatalf("expected ConfigMaps, got %q", resources[0].Kind)
+	}
+}
+
+func TestDiscover_MultipleKinds(t *testing.T) {
+	t.Parallel()
+
+	resources, err := Discover(newFakeDiscovery(), "ConfigMaps,Secrets")
+	if err != nil {
+		t.Fatalf("Discover returned error: %v", err)
+	}
+
+	if len(resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(resources))
+	}
+
+	if resources[0].Kind != "ConfigMaps" {
+		t.Fatalf("expected first resource to be ConfigMaps, got %q", resources[0].Kind)
+	}
+
+	if resources[1].Kind != "Secrets" {
+		t.Fatalf("expected second resource to be Secrets, got %q", resources[1].Kind)
+	}
+}
+
+func TestDiscover_PartialFailureContinues(t *testing.T) {
+	t.Parallel()
+
+	dc := newFakeDiscovery()
+	dc.PrependReactor("get", "resource", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("partial discovery failure")
+	})
+
+	resources, err := Discover(dc, "")
+	if err != nil {
+		t.Fatalf("expected partial failure to continue, got error: %v", err)
+	}
+
+	if len(resources) != 3 {
+		t.Fatalf("expected partial discovery to return listable resources, got %d", len(resources))
+	}
+}
+
+func newFakeDiscovery() *discoveryfake.FakeDiscovery {
+	return &discoveryfake.FakeDiscovery{
+		Fake: &k8stesting.Fake{
+			Resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: "v1",
+					APIResources: []metav1.APIResource{
+						{Kind: "Pods", Name: "pods", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
+						{Kind: "ConfigMaps", Name: "configmaps", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
+						{Kind: "Secrets", Name: "secrets", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
+						{Kind: "Widgets", Name: "widgets", Namespaced: true, Verbs: metav1.Verbs{"get"}},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/util/discover_test.go
+++ b/pkg/util/discover_test.go
@@ -35,8 +35,8 @@ func TestDiscover_FilterByKinds(t *testing.T) {
 		t.Fatalf("expected 1 resource, got %d", len(resources))
 	}
 
-	if resources[0].Kind != "ConfigMaps" {
-		t.Fatalf("expected ConfigMaps, got %q", resources[0].Kind)
+	if resources[0].Kind != "ConfigMap" {
+		t.Fatalf("expected ConfigMap, got %q", resources[0].Kind)
 	}
 }
 
@@ -49,8 +49,23 @@ func TestDiscover_SkipsNonListable(t *testing.T) {
 	}
 
 	for _, resource := range resources {
-		if resource.Kind == "Widgets" {
+		if resource.Kind == "Lease" {
 			t.Fatalf("expected non-listable resource to be skipped: %#v", resource)
+		}
+	}
+}
+
+func TestDiscover_SkipsUnsupportedListableKinds(t *testing.T) {
+	t.Parallel()
+
+	resources, err := Discover(newFakeDiscovery(), "")
+	if err != nil {
+		t.Fatalf("Discover returned error: %v", err)
+	}
+
+	for _, resource := range resources {
+		if resource.Kind == "Widget" {
+			t.Fatalf("expected unsupported listable resource to be skipped: %#v", resource)
 		}
 	}
 }
@@ -67,15 +82,15 @@ func TestDiscover_CaseInsensitive(t *testing.T) {
 		t.Fatalf("expected 1 resource, got %d", len(resources))
 	}
 
-	if resources[0].Kind != "ConfigMaps" {
-		t.Fatalf("expected ConfigMaps, got %q", resources[0].Kind)
+	if resources[0].Kind != "ConfigMap" {
+		t.Fatalf("expected ConfigMap, got %q", resources[0].Kind)
 	}
 }
 
 func TestDiscover_MultipleKinds(t *testing.T) {
 	t.Parallel()
 
-	resources, err := Discover(newFakeDiscovery(), "ConfigMaps,Secrets")
+	resources, err := Discover(newFakeDiscovery(), "Pods,ConfigMaps")
 	if err != nil {
 		t.Fatalf("Discover returned error: %v", err)
 	}
@@ -84,12 +99,33 @@ func TestDiscover_MultipleKinds(t *testing.T) {
 		t.Fatalf("expected 2 resources, got %d", len(resources))
 	}
 
-	if resources[0].Kind != "ConfigMaps" {
-		t.Fatalf("expected first resource to be ConfigMaps, got %q", resources[0].Kind)
+	if resources[0].Kind != "Pod" {
+		t.Fatalf("expected first resource to be Pod, got %q", resources[0].Kind)
 	}
 
-	if resources[1].Kind != "Secrets" {
-		t.Fatalf("expected second resource to be Secrets, got %q", resources[1].Kind)
+	if resources[1].Kind != "ConfigMap" {
+		t.Fatalf("expected second resource to be ConfigMap, got %q", resources[1].Kind)
+	}
+}
+
+func TestDiscover_AcceptsResourceNameForms(t *testing.T) {
+	t.Parallel()
+
+	resources, err := Discover(newFakeDiscovery(), "pods,secrets")
+	if err != nil {
+		t.Fatalf("Discover returned error: %v", err)
+	}
+
+	if len(resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(resources))
+	}
+
+	if resources[0].Kind != "Pod" {
+		t.Fatalf("expected first resource to be Pod, got %q", resources[0].Kind)
+	}
+
+	if resources[1].Kind != "Secret" {
+		t.Fatalf("expected second resource to be Secret, got %q", resources[1].Kind)
 	}
 }
 
@@ -118,10 +154,11 @@ func newFakeDiscovery() *discoveryfake.FakeDiscovery {
 				{
 					GroupVersion: "v1",
 					APIResources: []metav1.APIResource{
-						{Kind: "Pods", Name: "pods", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
-						{Kind: "ConfigMaps", Name: "configmaps", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
-						{Kind: "Secrets", Name: "secrets", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
-						{Kind: "Widgets", Name: "widgets", Namespaced: true, Verbs: metav1.Verbs{"get"}},
+						{Kind: "Pod", Name: "pods", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
+						{Kind: "ConfigMap", Name: "configmaps", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
+						{Kind: "Secret", Name: "secrets", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
+						{Kind: "Widget", Name: "widgets", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
+						{Kind: "Lease", Name: "leases", Namespaced: true, Verbs: metav1.Verbs{"get"}},
 					},
 				},
 			},

--- a/pkg/util/discover_test.go
+++ b/pkg/util/discover_test.go
@@ -4,9 +4,13 @@ import (
 	"errors"
 	"testing"
 
+	openapi_v2 "github.com/google/gnostic-models/openapiv2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/version"
 	discoveryfake "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/openapi"
+	"k8s.io/client-go/rest"
 	k8stesting "k8s.io/client-go/testing"
 )
 
@@ -155,24 +159,32 @@ func TestDiscover_PartialFailureContinues(t *testing.T) {
 func TestDiscover_DeduplicatesLogicalResourcesAcrossVersions(t *testing.T) {
 	t.Parallel()
 
-	dc := &discoveryfake.FakeDiscovery{
-		Fake: &k8stesting.Fake{
-			Resources: []*metav1.APIResourceList{
-				{
-					GroupVersion: "example.com/v1",
-					APIResources: []metav1.APIResource{
-						{Kind: "Widget", Name: "widgets", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
-					},
+	dc := newPreferredDiscovery(
+		[]*metav1.APIGroup{
+			{
+				Name: "example.com",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{GroupVersion: "example.com/v1beta1", Version: "v1beta1"},
+					{GroupVersion: "example.com/v1", Version: "v1"},
 				},
-				{
-					GroupVersion: "example.com/v1beta1",
-					APIResources: []metav1.APIResource{
-						{Kind: "Widget", Name: "widgets", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
-					},
+				PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: "example.com/v1", Version: "v1"},
+			},
+		},
+		[]*metav1.APIResourceList{
+			{
+				GroupVersion: "example.com/v1beta1",
+				APIResources: []metav1.APIResource{
+					{Kind: "Widget", Name: "widgets", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
+				},
+			},
+			{
+				GroupVersion: "example.com/v1",
+				APIResources: []metav1.APIResource{
+					{Kind: "Widget", Name: "widgets", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
 				},
 			},
 		},
-	}
+	)
 
 	resources, err := Discover(dc, "")
 	if err != nil {
@@ -184,7 +196,7 @@ func TestDiscover_DeduplicatesLogicalResourcesAcrossVersions(t *testing.T) {
 	}
 
 	if resources[0].APIVersion != "v1" {
-		t.Fatalf("expected first discovered version to be kept, got %q", resources[0].APIVersion)
+		t.Fatalf("expected preferred version to be kept, got %q", resources[0].APIVersion)
 	}
 }
 
@@ -241,4 +253,60 @@ func newFakeDiscovery() *discoveryfake.FakeDiscovery {
 			},
 		},
 	}
+}
+
+type preferredDiscovery struct {
+	*discoveryfake.FakeDiscovery
+	groups []*metav1.APIGroup
+}
+
+func newPreferredDiscovery(groups []*metav1.APIGroup, resources []*metav1.APIResourceList) *preferredDiscovery {
+	return &preferredDiscovery{
+		FakeDiscovery: &discoveryfake.FakeDiscovery{
+			Fake: &k8stesting.Fake{
+				Resources: resources,
+			},
+		},
+		groups: groups,
+	}
+}
+
+func (d *preferredDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return d.groups, d.Resources, nil
+}
+
+func (d *preferredDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+	return &metav1.APIGroupList{}, nil
+}
+
+func (d *preferredDiscovery) ServerResourcesForGroupVersion(string) (*metav1.APIResourceList, error) {
+	return nil, nil
+}
+
+func (d *preferredDiscovery) ServerResources() ([]*metav1.APIResourceList, error) {
+	return d.Resources, nil
+}
+
+func (d *preferredDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return nil, nil
+}
+
+func (d *preferredDiscovery) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	return nil, nil
+}
+
+func (d *preferredDiscovery) ServerVersion() (*version.Info, error) {
+	return &version.Info{}, nil
+}
+
+func (d *preferredDiscovery) OpenAPISchema() (*openapi_v2.Document, error) {
+	return &openapi_v2.Document{}, nil
+}
+
+func (d *preferredDiscovery) OpenAPIV3() openapi.Client {
+	return nil
+}
+
+func (d *preferredDiscovery) RESTClient() rest.Interface {
+	return nil
 }

--- a/pkg/util/discover_test.go
+++ b/pkg/util/discover_test.go
@@ -18,8 +18,8 @@ func TestDiscover_AllWhenEmpty(t *testing.T) {
 		t.Fatalf("Discover returned error: %v", err)
 	}
 
-	if len(resources) != 3 {
-		t.Fatalf("expected 3 listable resources, got %d", len(resources))
+	if len(resources) != 4 {
+		t.Fatalf("expected 4 listable resources, got %d", len(resources))
 	}
 }
 
@@ -55,7 +55,7 @@ func TestDiscover_SkipsNonListable(t *testing.T) {
 	}
 }
 
-func TestDiscover_SkipsUnsupportedListableKinds(t *testing.T) {
+func TestDiscover_ReturnsUnsupportedListableKinds(t *testing.T) {
 	t.Parallel()
 
 	resources, err := Discover(newFakeDiscovery(), "")
@@ -63,10 +63,15 @@ func TestDiscover_SkipsUnsupportedListableKinds(t *testing.T) {
 		t.Fatalf("Discover returned error: %v", err)
 	}
 
+	foundWidget := false
 	for _, resource := range resources {
 		if resource.Kind == "Widget" {
-			t.Fatalf("expected unsupported listable resource to be skipped: %#v", resource)
+			foundWidget = true
 		}
+	}
+
+	if !foundWidget {
+		t.Fatal("expected listable widget resource to be discovered")
 	}
 }
 
@@ -142,8 +147,44 @@ func TestDiscover_PartialFailureContinues(t *testing.T) {
 		t.Fatalf("expected partial failure to continue, got error: %v", err)
 	}
 
-	if len(resources) != 3 {
+	if len(resources) != 4 {
 		t.Fatalf("expected partial discovery to return listable resources, got %d", len(resources))
+	}
+}
+
+func TestDiscover_DeduplicatesLogicalResourcesAcrossVersions(t *testing.T) {
+	t.Parallel()
+
+	dc := &discoveryfake.FakeDiscovery{
+		Fake: &k8stesting.Fake{
+			Resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: "example.com/v1",
+					APIResources: []metav1.APIResource{
+						{Kind: "Widget", Name: "widgets", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
+					},
+				},
+				{
+					GroupVersion: "example.com/v1beta1",
+					APIResources: []metav1.APIResource{
+						{Kind: "Widget", Name: "widgets", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
+					},
+				},
+			},
+		},
+	}
+
+	resources, err := Discover(dc, "")
+	if err != nil {
+		t.Fatalf("Discover returned error: %v", err)
+	}
+
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 deduplicated resource, got %d", len(resources))
+	}
+
+	if resources[0].APIVersion != "v1" {
+		t.Fatalf("expected first discovered version to be kept, got %q", resources[0].APIVersion)
 	}
 }
 

--- a/pkg/util/discover_test.go
+++ b/pkg/util/discover_test.go
@@ -188,6 +188,42 @@ func TestDiscover_DeduplicatesLogicalResourcesAcrossVersions(t *testing.T) {
 	}
 }
 
+func TestDiscover_DeduplicatesBuiltinsAcrossGroups(t *testing.T) {
+	t.Parallel()
+
+	dc := &discoveryfake.FakeDiscovery{
+		Fake: &k8stesting.Fake{
+			Resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: "v1",
+					APIResources: []metav1.APIResource{
+						{Kind: "Event", Name: "events", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
+					},
+				},
+				{
+					GroupVersion: "events.k8s.io/v1",
+					APIResources: []metav1.APIResource{
+						{Kind: "Event", Name: "events", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
+					},
+				},
+			},
+		},
+	}
+
+	resources, err := Discover(dc, "")
+	if err != nil {
+		t.Fatalf("Discover returned error: %v", err)
+	}
+
+	if len(resources) != 1 {
+		t.Fatalf("expected 1 deduplicated event resource, got %d", len(resources))
+	}
+
+	if resources[0].APIGroup != "" || resources[0].APIVersion != "v1" {
+		t.Fatalf("expected core/v1 event to be kept, got %q/%q", resources[0].APIGroup, resources[0].APIVersion)
+	}
+}
+
 func newFakeDiscovery() *discoveryfake.FakeDiscovery {
 	return &discoveryfake.FakeDiscovery{
 		Fake: &k8stesting.Fake{

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -1,0 +1,189 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/cbor"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/client-go/rest"
+)
+
+var (
+	unstructuredScheme          = runtime.NewScheme()
+	unstructuredParameterScheme = runtime.NewScheme()
+	unstructuredParameterCodec  = runtime.NewParameterCodec(unstructuredParameterScheme)
+	versionV1                   = schema.GroupVersion{Version: "v1"}
+)
+
+func init() {
+	metav1.AddToGroupVersion(unstructuredScheme, versionV1)
+	metav1.AddToGroupVersion(unstructuredParameterScheme, versionV1)
+}
+
+func listUnstructuredResource(ctx context.Context, cfg *rest.Config, namespace string, meta ResourceMeta) (*unstructured.UnstructuredList, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("rest config is required for dynamic resource %s", meta.Resource)
+	}
+
+	httpClient, err := rest.HTTPClientFor(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := rest.UnversionedRESTClientForConfigAndClient(configForUnstructured(cfg), httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	segments := make([]string, 0, 6)
+	if meta.APIGroup == "" {
+		segments = append(segments, "api")
+	} else {
+		segments = append(segments, "apis", meta.APIGroup)
+	}
+	segments = append(segments, meta.APIVersion)
+	if meta.Namespaced && namespace != "" {
+		segments = append(segments, "namespaces", namespace)
+	}
+	segments = append(segments, meta.Resource)
+
+	var out unstructured.UnstructuredList
+	if err := client.Get().
+		AbsPath(segments...).
+		SpecificallyVersionedParams(&metav1.ListOptions{}, unstructuredParameterCodec, versionV1).
+		Do(ctx).
+		Into(&out); err != nil {
+		return nil, err
+	}
+
+	out.SetKind(meta.Kind)
+	out.SetAPIVersion(joinGroupVersion(meta.APIGroup, meta.APIVersion))
+
+	return &out, nil
+}
+
+func configForUnstructured(inConfig *rest.Config) *rest.Config {
+	config := rest.CopyConfig(inConfig)
+	config.ContentType = "application/json"
+	config.AcceptContentTypes = "application/json"
+	config.GroupVersion = nil
+	config.APIPath = "/"
+	config.NegotiatedSerializer = basicUnstructuredNegotiatedSerializer{
+		supportedMediaTypes: []runtime.SerializerInfo{
+			{
+				MediaType:        "application/json",
+				MediaTypeType:    "application",
+				MediaTypeSubType: "json",
+				EncodesAsText:    true,
+				Serializer:       json.NewSerializerWithOptions(json.DefaultMetaFactory, unstructuredCreater{nested: unstructuredScheme}, unstructuredTyper{nested: unstructuredScheme}, json.SerializerOptions{}),
+				PrettySerializer: json.NewSerializerWithOptions(json.DefaultMetaFactory, unstructuredCreater{nested: unstructuredScheme}, unstructuredTyper{nested: unstructuredScheme}, json.SerializerOptions{Pretty: true}),
+				StreamSerializer: &runtime.StreamSerializerInfo{
+					EncodesAsText: true,
+					Serializer:    json.NewSerializerWithOptions(json.DefaultMetaFactory, unstructuredScheme, unstructuredScheme, json.SerializerOptions{}),
+					Framer:        json.Framer,
+				},
+			},
+			{
+				MediaType:        "application/cbor",
+				MediaTypeType:    "application",
+				MediaTypeSubType: "cbor",
+				Serializer:       cbor.NewSerializer(unstructuredCreater{nested: unstructuredScheme}, unstructuredTyper{nested: unstructuredScheme}),
+				StreamSerializer: &runtime.StreamSerializerInfo{
+					Serializer: cbor.NewSerializer(unstructuredScheme, unstructuredScheme, cbor.Transcode(false)),
+					Framer:     cbor.NewFramer(),
+				},
+			},
+		},
+	}
+
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	return config
+}
+
+func joinGroupVersion(group, version string) string {
+	if group == "" {
+		return version
+	}
+	return group + "/" + version
+}
+
+type basicUnstructuredNegotiatedSerializer struct {
+	supportedMediaTypes []runtime.SerializerInfo
+}
+
+func (s basicUnstructuredNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return s.supportedMediaTypes
+}
+
+func (s basicUnstructuredNegotiatedSerializer) EncoderForVersion(encoder runtime.Encoder, gv runtime.GroupVersioner) runtime.Encoder {
+	return runtime.WithVersionEncoder{
+		Version:     gv,
+		Encoder:     encoder,
+		ObjectTyper: permissiveTyper{nested: unstructuredScheme},
+	}
+}
+
+func (s basicUnstructuredNegotiatedSerializer) DecoderToVersion(decoder runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	return decoder
+}
+
+type unstructuredCreater struct {
+	nested runtime.ObjectCreater
+}
+
+func (c unstructuredCreater) New(kind schema.GroupVersionKind) (runtime.Object, error) {
+	out, err := c.nested.New(kind)
+	if err == nil {
+		return out, nil
+	}
+
+	out = &unstructured.Unstructured{}
+	out.GetObjectKind().SetGroupVersionKind(kind)
+	return out, nil
+}
+
+type unstructuredTyper struct {
+	nested runtime.ObjectTyper
+}
+
+func (t unstructuredTyper) ObjectKinds(obj runtime.Object) ([]schema.GroupVersionKind, bool, error) {
+	kinds, unversioned, err := t.nested.ObjectKinds(obj)
+	if err == nil {
+		return kinds, unversioned, nil
+	}
+	if _, ok := obj.(runtime.Unstructured); ok && !obj.GetObjectKind().GroupVersionKind().Empty() {
+		return []schema.GroupVersionKind{obj.GetObjectKind().GroupVersionKind()}, false, nil
+	}
+	return nil, false, err
+}
+
+func (t unstructuredTyper) Recognizes(gvk schema.GroupVersionKind) bool {
+	return true
+}
+
+type permissiveTyper struct {
+	nested runtime.ObjectTyper
+}
+
+func (t permissiveTyper) ObjectKinds(obj runtime.Object) ([]schema.GroupVersionKind, bool, error) {
+	kinds, unversioned, err := t.nested.ObjectKinds(obj)
+	if err == nil {
+		return kinds, unversioned, nil
+	}
+	if _, ok := obj.(runtime.Unstructured); ok {
+		return []schema.GroupVersionKind{obj.GetObjectKind().GroupVersionKind()}, false, nil
+	}
+	return nil, false, err
+}
+
+func (t permissiveTyper) Recognizes(gvk schema.GroupVersionKind) bool {
+	return true
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,24 +6,22 @@ import (
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 // Getter the
 // This should be go routine ready. Such that getter can be called via goroutines and over a channel the value can be passed to a switch type through with the respective printer can be called.
-func Getter(namespace string, clientset kubernetes.Interface, resources []ResourceMeta, c chan interface{}) {
+func Getter(namespace string, clientset kubernetes.Interface, restConfig *rest.Config, resources []ResourceMeta, c chan interface{}) {
 	defer close(c)
 	ctx := context.Background()
-	var err error
-	var list interface{}
 
 	for _, meta := range resources {
-		resourceName, ok := canonicalResourceName(meta.Kind, meta.Resource)
-		if !ok {
-			log.Debugf("kind %q not handled, skipping", meta.Kind)
-			continue
-		}
+		var (
+			err  error
+			list interface{}
+		)
 
-		switch resourceName {
+		switch canonicalResourceName(meta.Kind, meta.Resource) {
 		case "pods":
 			list, err = clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
@@ -78,8 +76,13 @@ func Getter(namespace string, clientset kubernetes.Interface, resources []Resour
 			list, err = clientset.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
 		default:
-			log.Debugf("kind %q not handled, skipping", meta.Kind)
-			continue
+			var dynamicList interface{}
+			unstructuredList, listErr := listUnstructuredResource(ctx, restConfig, namespace, meta)
+			if unstructuredList != nil {
+				dynamicList = unstructuredList
+			}
+			list, err = dynamicList, listErr
+			handleError(err, meta.Kind)
 		}
 
 		if list != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -26,61 +26,62 @@ func Getter(namespace string, clientset kubernetes.Interface, restConfig *rest.C
 			list interface{}
 		)
 
-		switch canonicalResourceName(meta.Kind, meta.Resource) {
-		case "pods":
-			list, err = clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, meta.Kind)
-		case "configmaps":
-			list, err = clientset.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, meta.Kind)
-		case "endpoints":
-			list, err = clientset.CoreV1().Endpoints(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, meta.Kind)
-		case "events":
-			list, err = clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, meta.Kind)
-		case "limitranges":
-			list, err = clientset.CoreV1().LimitRanges(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, meta.Kind)
-		case "namespaces":
-			list, err = clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
-			handleError(err, meta.Kind)
-		case "persistentvolumes":
-			list, err = clientset.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
-			handleError(err, meta.Kind)
-		case "persistentvolumeclaims":
-			list, err = clientset.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, meta.Kind)
-		case "podtemplates":
-			list, err = clientset.CoreV1().PodTemplates(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, meta.Kind)
-		case "resourcequotas":
-			list, err = clientset.CoreV1().ResourceQuotas(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, meta.Kind)
-		case "secrets":
-			list, err = clientset.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, meta.Kind)
-		case "services":
-			list, err = clientset.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, meta.Kind)
-		case "serviceaccounts":
-			list, err = clientset.CoreV1().ServiceAccounts(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, meta.Kind)
-
-		// these will be from the AppsV1
-		case "daemonsets":
-			list, err = clientset.AppsV1().DaemonSets(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, meta.Kind)
-		case "deployments":
-			list, err = clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, meta.Kind)
-		case "replicasets":
-			list, err = clientset.AppsV1().ReplicaSets(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, meta.Kind)
-		case "statefulsets":
-			list, err = clientset.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, meta.Kind)
-		default:
+		canonical := canonicalResourceName(meta.Kind, meta.Resource)
+		if canonical != "" && endpointMatchesTyped(meta, canonical) {
+			switch canonical {
+			case "pods":
+				list, err = clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+				handleError(err, meta.Kind)
+			case "configmaps":
+				list, err = clientset.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{})
+				handleError(err, meta.Kind)
+			case "endpoints":
+				list, err = clientset.CoreV1().Endpoints(namespace).List(ctx, metav1.ListOptions{})
+				handleError(err, meta.Kind)
+			case "events":
+				list, err = clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
+				handleError(err, meta.Kind)
+			case "limitranges":
+				list, err = clientset.CoreV1().LimitRanges(namespace).List(ctx, metav1.ListOptions{})
+				handleError(err, meta.Kind)
+			case "namespaces":
+				list, err = clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+				handleError(err, meta.Kind)
+			case "persistentvolumes":
+				list, err = clientset.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+				handleError(err, meta.Kind)
+			case "persistentvolumeclaims":
+				list, err = clientset.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+				handleError(err, meta.Kind)
+			case "podtemplates":
+				list, err = clientset.CoreV1().PodTemplates(namespace).List(ctx, metav1.ListOptions{})
+				handleError(err, meta.Kind)
+			case "resourcequotas":
+				list, err = clientset.CoreV1().ResourceQuotas(namespace).List(ctx, metav1.ListOptions{})
+				handleError(err, meta.Kind)
+			case "secrets":
+				list, err = clientset.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{})
+				handleError(err, meta.Kind)
+			case "services":
+				list, err = clientset.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{})
+				handleError(err, meta.Kind)
+			case "serviceaccounts":
+				list, err = clientset.CoreV1().ServiceAccounts(namespace).List(ctx, metav1.ListOptions{})
+				handleError(err, meta.Kind)
+			case "daemonsets":
+				list, err = clientset.AppsV1().DaemonSets(namespace).List(ctx, metav1.ListOptions{})
+				handleError(err, meta.Kind)
+			case "deployments":
+				list, err = clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+				handleError(err, meta.Kind)
+			case "replicasets":
+				list, err = clientset.AppsV1().ReplicaSets(namespace).List(ctx, metav1.ListOptions{})
+				handleError(err, meta.Kind)
+			case "statefulsets":
+				list, err = clientset.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
+				handleError(err, meta.Kind)
+			}
+		} else {
 			var dynamicList interface{}
 			unstructuredList, listErr := listUnstructuredResource(ctx, restConfig, namespace, meta)
 			if unstructuredList != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -9,9 +9,14 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+type FetchResult struct {
+	Kind     string
+	Resource interface{}
+}
+
 // Getter the
 // This should be go routine ready. Such that getter can be called via goroutines and over a channel the value can be passed to a switch type through with the respective printer can be called.
-func Getter(namespace string, clientset kubernetes.Interface, restConfig *rest.Config, resources []ResourceMeta, c chan interface{}) {
+func Getter(namespace string, clientset kubernetes.Interface, restConfig *rest.Config, resources []ResourceMeta, c chan FetchResult) {
 	defer close(c)
 	ctx := context.Background()
 
@@ -85,9 +90,7 @@ func Getter(namespace string, clientset kubernetes.Interface, restConfig *rest.C
 			handleError(err, meta.Kind)
 		}
 
-		if list != nil {
-			c <- list
-		}
+		c <- FetchResult{Kind: meta.Kind, Resource: list}
 	}
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2,110 +2,83 @@ package util
 
 import (
 	"context"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
-var resources = []string{
-	"Pods",
-	"ConfigMaps",
-	"Endpoints",
-	"Events",
-	"LimitRanges",
-	"Namespaces",
-	"PersistentVolumes",
-	"PersistentVolumeClaims",
-	"PodTemplates",
-	"ResourceQuotas",
-	"Secrets",
-	"Services",
-	"ServiceAccounts",
-	"DaemonSets",
-	"Deployments",
-	"ReplicaSets",
-	"StatefulSets",
-}
-
-func configuredResources(kinds string) []string {
-	if kinds == "" {
-		return append([]string(nil), resources...)
-	}
-
-	return strings.Split(kinds, ",")
-}
-
 // Getter the
 // This should be go routine ready. Such that getter can be called via goroutines and over a channel the value can be passed to a switch type through with the respective printer can be called.
-func Getter(namespace string, clientset kubernetes.Interface, kinds string, c chan interface{}) {
+func Getter(namespace string, clientset kubernetes.Interface, resources []ResourceMeta, c chan interface{}) {
 	defer close(c)
 	ctx := context.Background()
 	var err error
 	var list interface{}
 
-	for _, resource := range configuredResources(kinds) {
-		switch resource {
-		case "Pods":
+	for _, meta := range resources {
+		switch meta.Kind {
+		case "Pod", "Pods":
 			list, err = clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, resource)
-		case "ConfigMaps":
+			handleError(err, meta.Kind)
+		case "ConfigMap", "ConfigMaps":
 			list, err = clientset.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, resource)
-		case "Endpoints":
+			handleError(err, meta.Kind)
+		case "Endpoint", "Endpoints":
 			list, err = clientset.CoreV1().Endpoints(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, resource)
-		case "Events":
+			handleError(err, meta.Kind)
+		case "Event", "Events":
 			list, err = clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, resource)
-		case "LimitRanges":
+			handleError(err, meta.Kind)
+		case "LimitRange", "LimitRanges":
 			list, err = clientset.CoreV1().LimitRanges(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, resource)
-		case "Namespaces":
+			handleError(err, meta.Kind)
+		case "Namespace", "Namespaces":
 			list, err = clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
-			handleError(err, resource)
-		case "PersistentVolumes":
+			handleError(err, meta.Kind)
+		case "PersistentVolume", "PersistentVolumes":
 			list, err = clientset.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
-			handleError(err, resource)
-		case "PersistentVolumeClaims":
+			handleError(err, meta.Kind)
+		case "PersistentVolumeClaim", "PersistentVolumeClaims":
 			list, err = clientset.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, resource)
-		case "PodTemplates":
+			handleError(err, meta.Kind)
+		case "PodTemplate", "PodTemplates":
 			list, err = clientset.CoreV1().PodTemplates(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, resource)
-		case "ResourceQuotas":
+			handleError(err, meta.Kind)
+		case "ResourceQuota", "ResourceQuotas":
 			list, err = clientset.CoreV1().ResourceQuotas(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, resource)
-		case "Secrets":
+			handleError(err, meta.Kind)
+		case "Secret", "Secrets":
 			list, err = clientset.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, resource)
-		case "Services":
+			handleError(err, meta.Kind)
+		case "Service", "Services":
 			list, err = clientset.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, resource)
-		case "ServiceAccounts":
+			handleError(err, meta.Kind)
+		case "ServiceAccount", "ServiceAccounts":
 			list, err = clientset.CoreV1().ServiceAccounts(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, resource)
+			handleError(err, meta.Kind)
 
 		// these will be from the AppsV1
-		case "DaemonSets":
+		case "DaemonSet", "DaemonSets":
 			list, err = clientset.AppsV1().DaemonSets(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, resource)
-		case "Deployments":
+			handleError(err, meta.Kind)
+		case "Deployment", "Deployments":
 			list, err = clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, resource)
-		case "ReplicaSets":
+			handleError(err, meta.Kind)
+		case "ReplicaSet", "ReplicaSets":
 			list, err = clientset.AppsV1().ReplicaSets(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, resource)
-		case "StatefulSets":
+			handleError(err, meta.Kind)
+		case "StatefulSet", "StatefulSets":
 			list, err = clientset.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
-			handleError(err, resource)
+			handleError(err, meta.Kind)
 		default:
-			log.Error("Given kind is not supported")
-			return
+			log.Debugf("kind %q not handled, skipping", meta.Kind)
+			continue
 		}
 
-		c <- list
+		if list != nil {
+			c <- list
+		}
 	}
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -17,58 +17,64 @@ func Getter(namespace string, clientset kubernetes.Interface, resources []Resour
 	var list interface{}
 
 	for _, meta := range resources {
-		switch meta.Kind {
-		case "Pod", "Pods":
+		resourceName, ok := canonicalResourceName(meta.Kind, meta.Resource)
+		if !ok {
+			log.Debugf("kind %q not handled, skipping", meta.Kind)
+			continue
+		}
+
+		switch resourceName {
+		case "pods":
 			list, err = clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
-		case "ConfigMap", "ConfigMaps":
+		case "configmaps":
 			list, err = clientset.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
-		case "Endpoint", "Endpoints":
+		case "endpoints":
 			list, err = clientset.CoreV1().Endpoints(namespace).List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
-		case "Event", "Events":
+		case "events":
 			list, err = clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
-		case "LimitRange", "LimitRanges":
+		case "limitranges":
 			list, err = clientset.CoreV1().LimitRanges(namespace).List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
-		case "Namespace", "Namespaces":
+		case "namespaces":
 			list, err = clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
-		case "PersistentVolume", "PersistentVolumes":
+		case "persistentvolumes":
 			list, err = clientset.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
-		case "PersistentVolumeClaim", "PersistentVolumeClaims":
+		case "persistentvolumeclaims":
 			list, err = clientset.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
-		case "PodTemplate", "PodTemplates":
+		case "podtemplates":
 			list, err = clientset.CoreV1().PodTemplates(namespace).List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
-		case "ResourceQuota", "ResourceQuotas":
+		case "resourcequotas":
 			list, err = clientset.CoreV1().ResourceQuotas(namespace).List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
-		case "Secret", "Secrets":
+		case "secrets":
 			list, err = clientset.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
-		case "Service", "Services":
+		case "services":
 			list, err = clientset.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
-		case "ServiceAccount", "ServiceAccounts":
+		case "serviceaccounts":
 			list, err = clientset.CoreV1().ServiceAccounts(namespace).List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
 
 		// these will be from the AppsV1
-		case "DaemonSet", "DaemonSets":
+		case "daemonsets":
 			list, err = clientset.AppsV1().DaemonSets(namespace).List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
-		case "Deployment", "Deployments":
+		case "deployments":
 			list, err = clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
-		case "ReplicaSet", "ReplicaSets":
+		case "replicasets":
 			list, err = clientset.AppsV1().ReplicaSets(namespace).List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
-		case "StatefulSet", "StatefulSets":
+		case "statefulsets":
 			list, err = clientset.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
 			handleError(err, meta.Kind)
 		default:

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -23,24 +23,28 @@ func TestGetter_CustomKinds(t *testing.T) {
 		},
 	})
 
-	results := make(chan interface{})
+	results := make(chan FetchResult)
 
 	go Getter("default", clientset, nil, []ResourceMeta{
 		{Kind: "ConfigMap", Resource: "configmaps", Namespaced: true},
 	}, results)
 
-	var received []interface{}
-	for item := range results {
-		received = append(received, item)
+	var received []FetchResult
+	for result := range results {
+		received = append(received, result)
 	}
 
 	if len(received) != 1 {
 		t.Fatalf("expected exactly one result, got %d", len(received))
 	}
 
-	configMaps, ok := received[0].(*v1.ConfigMapList)
+	if received[0].Kind != "ConfigMap" {
+		t.Fatalf("expected kind ConfigMap, got %q", received[0].Kind)
+	}
+
+	configMaps, ok := received[0].Resource.(*v1.ConfigMapList)
 	if !ok {
-		t.Fatalf("expected *v1.ConfigMapList, got %T", received[0])
+		t.Fatalf("expected *v1.ConfigMapList, got %T", received[0].Resource)
 	}
 
 	if len(configMaps.Items) != 1 {
@@ -52,11 +56,26 @@ func TestGetter_UnknownKind(t *testing.T) {
 	t.Parallel()
 
 	clientset := fake.NewSimpleClientset()
-	results := make(chan interface{})
+	results := make(chan FetchResult)
 
 	go Getter("default", clientset, nil, []ResourceMeta{
 		{Kind: "NonExistentKind", Resource: "nonexistentkinds", Namespaced: true},
 	}, results)
+
+	select {
+	case result, ok := <-results:
+		if !ok {
+			t.Fatal("expected placeholder result before channel close")
+		}
+		if result.Kind != "NonExistentKind" {
+			t.Fatalf("expected kind NonExistentKind, got %q", result.Kind)
+		}
+		if result.Resource != nil {
+			t.Fatalf("expected nil resource for unknown kind, got %#v", result.Resource)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for placeholder result")
+	}
 
 	select {
 	case _, ok := <-results:
@@ -77,7 +96,7 @@ func TestGetter_ChannelAlwaysClosed(t *testing.T) {
 			Namespace: "default",
 		},
 	})
-	results := make(chan interface{})
+	results := make(chan FetchResult)
 
 	go Getter("default", clientset, nil, []ResourceMeta{
 		{Kind: "Pod", Resource: "pods", Namespaced: true},
@@ -114,7 +133,7 @@ func TestGetter_CustomResource(t *testing.T) {
 	defer server.Close()
 
 	clientset := fake.NewSimpleClientset()
-	results := make(chan interface{})
+	results := make(chan FetchResult)
 	cfg := &rest.Config{Host: server.URL}
 
 	go Getter("default", clientset, cfg, []ResourceMeta{
@@ -122,14 +141,18 @@ func TestGetter_CustomResource(t *testing.T) {
 	}, results)
 
 	select {
-	case item, ok := <-results:
+	case result, ok := <-results:
 		if !ok {
 			t.Fatal("expected custom resource list before channel close")
 		}
 
-		list, ok := item.(*unstructured.UnstructuredList)
+		if result.Kind != "Widget" {
+			t.Fatalf("expected kind Widget, got %q", result.Kind)
+		}
+
+		list, ok := result.Resource.(*unstructured.UnstructuredList)
 		if !ok {
-			t.Fatalf("expected *unstructured.UnstructuredList, got %T", item)
+			t.Fatalf("expected *unstructured.UnstructuredList, got %T", result.Resource)
 		}
 
 		if list.GetKind() != "Widget" {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -21,7 +21,9 @@ func TestGetter_CustomKinds(t *testing.T) {
 
 	results := make(chan interface{})
 
-	go Getter("default", clientset, "ConfigMaps", results)
+	go Getter("default", clientset, []ResourceMeta{
+		{Kind: "ConfigMaps", Resource: "configmaps", Namespaced: true},
+	}, results)
 
 	var received []interface{}
 	for item := range results {
@@ -48,7 +50,9 @@ func TestGetter_UnknownKind(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
 	results := make(chan interface{})
 
-	go Getter("default", clientset, "NonExistentKind", results)
+	go Getter("default", clientset, []ResourceMeta{
+		{Kind: "NonExistentKind", Resource: "nonexistentkinds", Namespaced: true},
+	}, results)
 
 	select {
 	case _, ok := <-results:
@@ -71,7 +75,9 @@ func TestGetter_ChannelAlwaysClosed(t *testing.T) {
 	})
 	results := make(chan interface{})
 
-	go Getter("default", clientset, "Pods", results)
+	go Getter("default", clientset, []ResourceMeta{
+		{Kind: "Pods", Resource: "pods", Namespaced: true},
+	}, results)
 
 	done := make(chan struct{})
 	go func() {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -26,7 +26,7 @@ func TestGetter_CustomKinds(t *testing.T) {
 	results := make(chan FetchResult)
 
 	go Getter("default", clientset, nil, []ResourceMeta{
-		{Kind: "ConfigMap", Resource: "configmaps", Namespaced: true},
+		{Kind: "ConfigMap", Resource: "configmaps", APIVersion: "v1", Namespaced: true},
 	}, results)
 
 	var received []FetchResult
@@ -99,7 +99,7 @@ func TestGetter_ChannelAlwaysClosed(t *testing.T) {
 	results := make(chan FetchResult)
 
 	go Getter("default", clientset, nil, []ResourceMeta{
-		{Kind: "Pod", Resource: "pods", Namespaced: true},
+		{Kind: "Pod", Resource: "pods", APIVersion: "v1", Namespaced: true},
 	}, results)
 
 	done := make(chan struct{})
@@ -170,6 +170,66 @@ func TestGetter_CustomResource(t *testing.T) {
 	case _, ok := <-results:
 		if ok {
 			t.Fatal("expected channel to be closed after custom resource result")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for channel to close")
+	}
+}
+
+func TestGetter_UsesDynamicPathWhenDiscoveredEndpointDiffers(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/apis/events.k8s.io/v1/namespaces/default/events" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"apiVersion":"events.k8s.io/v1","kind":"EventList","metadata":{},"items":[{"apiVersion":"events.k8s.io/v1","kind":"Event","metadata":{"name":"demo","namespace":"default"}}]}`))
+	}))
+	defer server.Close()
+
+	clientset := fake.NewSimpleClientset()
+	results := make(chan FetchResult)
+	cfg := &rest.Config{Host: server.URL}
+
+	go Getter("default", clientset, cfg, []ResourceMeta{
+		{Kind: "Event", Resource: "events", APIGroup: "events.k8s.io", APIVersion: "v1", Namespaced: true},
+	}, results)
+
+	select {
+	case result, ok := <-results:
+		if !ok {
+			t.Fatal("expected migrated resource list before channel close")
+		}
+
+		if result.Kind != "Event" {
+			t.Fatalf("expected kind Event, got %q", result.Kind)
+		}
+
+		list, ok := result.Resource.(*unstructured.UnstructuredList)
+		if !ok {
+			t.Fatalf("expected *unstructured.UnstructuredList, got %T", result.Resource)
+		}
+
+		if list.GetAPIVersion() != "events.k8s.io/v1" {
+			t.Fatalf("expected events.k8s.io/v1, got %q", list.GetAPIVersion())
+		}
+
+		if len(list.Items) != 1 || list.Items[0].GetName() != "demo" {
+			t.Fatalf("unexpected migrated resource items: %#v", list.Items)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for migrated resource result")
+	}
+
+	select {
+	case _, ok := <-results:
+		if ok {
+			t.Fatal("expected channel to be closed after migrated resource result")
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for channel to close")

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -22,7 +22,7 @@ func TestGetter_CustomKinds(t *testing.T) {
 	results := make(chan interface{})
 
 	go Getter("default", clientset, []ResourceMeta{
-		{Kind: "ConfigMaps", Resource: "configmaps", Namespaced: true},
+		{Kind: "ConfigMap", Resource: "configmaps", Namespaced: true},
 	}, results)
 
 	var received []interface{}
@@ -76,7 +76,7 @@ func TestGetter_ChannelAlwaysClosed(t *testing.T) {
 	results := make(chan interface{})
 
 	go Getter("default", clientset, []ResourceMeta{
-		{Kind: "Pods", Resource: "pods", Namespaced: true},
+		{Kind: "Pod", Resource: "pods", Namespaced: true},
 	}, results)
 
 	done := make(chan struct{})

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,12 +1,16 @@
 package util
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 )
 
 func TestGetter_CustomKinds(t *testing.T) {
@@ -21,7 +25,7 @@ func TestGetter_CustomKinds(t *testing.T) {
 
 	results := make(chan interface{})
 
-	go Getter("default", clientset, []ResourceMeta{
+	go Getter("default", clientset, nil, []ResourceMeta{
 		{Kind: "ConfigMap", Resource: "configmaps", Namespaced: true},
 	}, results)
 
@@ -50,7 +54,7 @@ func TestGetter_UnknownKind(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
 	results := make(chan interface{})
 
-	go Getter("default", clientset, []ResourceMeta{
+	go Getter("default", clientset, nil, []ResourceMeta{
 		{Kind: "NonExistentKind", Resource: "nonexistentkinds", Namespaced: true},
 	}, results)
 
@@ -75,7 +79,7 @@ func TestGetter_ChannelAlwaysClosed(t *testing.T) {
 	})
 	results := make(chan interface{})
 
-	go Getter("default", clientset, []ResourceMeta{
+	go Getter("default", clientset, nil, []ResourceMeta{
 		{Kind: "Pod", Resource: "pods", Namespaced: true},
 	}, results)
 
@@ -88,6 +92,62 @@ func TestGetter_ChannelAlwaysClosed(t *testing.T) {
 
 	select {
 	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for channel to close")
+	}
+}
+
+func TestGetter_CustomResource(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET request, got %s", r.Method)
+		}
+		if r.URL.Path != "/apis/example.com/v1/namespaces/default/widgets" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"apiVersion":"example.com/v1","kind":"WidgetList","metadata":{},"items":[{"apiVersion":"example.com/v1","kind":"Widget","metadata":{"name":"demo","namespace":"default"}}]}`))
+	}))
+	defer server.Close()
+
+	clientset := fake.NewSimpleClientset()
+	results := make(chan interface{})
+	cfg := &rest.Config{Host: server.URL}
+
+	go Getter("default", clientset, cfg, []ResourceMeta{
+		{Kind: "Widget", Resource: "widgets", APIGroup: "example.com", APIVersion: "v1", Namespaced: true},
+	}, results)
+
+	select {
+	case item, ok := <-results:
+		if !ok {
+			t.Fatal("expected custom resource list before channel close")
+		}
+
+		list, ok := item.(*unstructured.UnstructuredList)
+		if !ok {
+			t.Fatalf("expected *unstructured.UnstructuredList, got %T", item)
+		}
+
+		if list.GetKind() != "Widget" {
+			t.Fatalf("expected list kind Widget, got %q", list.GetKind())
+		}
+
+		if len(list.Items) != 1 || list.Items[0].GetName() != "demo" {
+			t.Fatalf("unexpected custom resource items: %#v", list.Items)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for custom resource result")
+	}
+
+	select {
+	case _, ok := <-results:
+		if ok {
+			t.Fatal("expected channel to be closed after custom resource result")
+		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for channel to close")
 	}


### PR DESCRIPTION
Reference: `openspec/changes/0006-dynamic-resource-discovery/`

## Summary
This change replaces the duplicated static resource lists in `pkg/util/util.go` and `cmd/ksearch.go` with live discovery from the Kubernetes API server.

It adds `pkg/util/discover.go` with `ResourceMeta` and `Discover(...)`, uses `ServerGroupsAndResources()` to discover listable resources at runtime, tolerates partial discovery failures, and applies case-insensitive `--kinds` filtering. `Getter(...)` now consumes discovered `[]ResourceMeta`, normalizes singular/plural kind names, and skips unhandled kinds at debug level instead of treating them as fatal. `cmd/ksearch.go` now uses discovery as the single source of truth for resource ordering and fetch execution.

Why: change 0006 requires removing duplicated hardcoded resource-kind lists and switching to runtime discovery so the search set is driven by the API server rather than stale static lists.

## Verification
- `gofmt -w .`
- `go build ./...`
- `go vet ./...`
- `go test -race ./pkg/util/...`
- `go test -race ./...`

`go test -race ./...` result:
```text
?    github.com/arush-sal/ksearch [no test files]
?    github.com/arush-sal/ksearch/cmd [no test files]
ok   github.com/arush-sal/ksearch/pkg/cache (cached)
ok   github.com/arush-sal/ksearch/pkg/printers 1.035s
ok   github.com/arush-sal/ksearch/pkg/util 1.037s
```

## Security / Gate Checks
- `grep -rn "defaultResources" . --include="*.go"` => no matches
- `grep -rn "effectiveResources" . --include="*.go"` => no matches
- `grep -rn "configuredResources" . --include="*.go"` => no matches
