### PR TITLE
docs: refresh README and contributor docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,11 @@
 
 `ksearch` is a Go CLI kubectl plugin for comprehensive Kubernetes resource discovery.
 Entry points are `main.go` (calls `cmd.Execute()`) and `cmd/ksearch.go` (Cobra flags,
-client init, result dispatch). Core resource fetching is in `pkg/util/util.go`;
-stdout rendering is in `pkg/printers/printers.go`. Dependency snapshots are checked
-into `vendor/`. Design proposals and planned changes live under `openspec/`; treat
-those as implementation guidance, not runtime code.
+client init, cache handling, discovery, result dispatch). Core resource fetching is in
+`pkg/util/`; stdout rendering is in `pkg/printers/`; local cache logic is in
+`pkg/cache/`. Dependency snapshots are checked into `vendor/`. Design proposals and
+planned changes live under `openspec/`; treat those as implementation guidance, not
+runtime code.
 
 ### Data flow
 
@@ -18,10 +19,10 @@ cmd/ksearch.go  ──► pkg/util/util.go  ──► pkg/printers/printers.go
   result loop)        chan interface{})
 ```
 
-The channel carries concrete typed Kubernetes list structs (`*v1.PodList`,
-`*appsv1.DeploymentList`, etc.). The type switch in `Printer()` must cover every
-type `Getter()` can emit. **Adding a resource kind requires changes in both
-`pkg/util/util.go` and `pkg/printers/printers.go`.**
+The fetch path now supports both typed Kubernetes list structs (`*v1.PodList`,
+`*appsv1.DeploymentList`, etc.) and dynamically discovered unstructured lists.
+The type switch in `Printer()` must cover every typed result `Getter()` can emit,
+and unstructured output must remain sensible for dynamically discovered resources.
 
 ### Planned upgrades (openspec/)
 
@@ -38,10 +39,11 @@ Completed change specs are in `openspec/changes/done/<id>/` for reference.
 
 ## Build, Test, and Development Commands
 
-No Makefile. Use standard Go tooling.
+Use the `Makefile` for common tasks, or standard Go tooling directly.
 
 ```bash
 # Build
+make build
 go build -o ksearch .
 
 # Run
@@ -51,15 +53,21 @@ go build -o ksearch .
 ./ksearch -k configmap,secret -n default
 
 # Test
+make test
 go test ./...                         # all packages
 go test ./pkg/printers/...            # single package
 go test -run TestMatchesPattern ./pkg/printers/...   # single test
 go test -v -count=1 ./...             # verbose, no cache
 
 # Vet and format
+make vet
 go vet ./...
+make fmt
 gofmt -l .                            # list files that need formatting
 gofmt -w .                            # apply formatting
+
+# Lint
+make lint
 ```
 
 The binary is `.gitignored`; rebuild after every source change.
@@ -71,7 +79,7 @@ The binary is `.gitignored`; rebuild after every source change.
 - Tabs for indentation; `gofmt` formatting enforced.
 - Exported identifiers only when cross-package use requires them.
 - Keep CLI wiring in `cmd/`, Kubernetes API fetch logic in `pkg/util/`, formatting
-  logic in `pkg/printers/`, cache logic in `pkg/cache/` (planned).
+  logic in `pkg/printers/`, cache logic in `pkg/cache/`.
 - Error handling: log via `logrus` and continue rather than `log.Fatal`/`panic`
   inside library packages; reserve `OrDie` helpers for `cmd/` init paths only.
 
@@ -79,8 +87,8 @@ The binary is `.gitignored`; rebuild after every source change.
 
 ## Testing Scope
 
-Tests do not yet exist. The following test strategy should be followed when
-implementing new code or the planned changes above.
+Tests already exist across command, cache, printer, and util packages. New work
+should follow and extend the existing test patterns below.
 
 ### pkg/printers
 
@@ -90,8 +98,7 @@ implementing new code or the planned changes above.
 | `TestPrinter_<Kind>` | Given a populated `*v1.XList`, `Printer()` writes expected header and rows to a `bytes.Buffer`; empty list writes nothing |
 | `TestPrinter_PatternFilter` | Rows not matching the pattern are absent from output |
 
-Use `bytes.Buffer` as the `io.Writer` target once the `0002` refactor lands.
-Until then, capture stdout with `os.Pipe()`.
+Use `bytes.Buffer` as the `io.Writer` target.
 
 ### pkg/util
 
@@ -103,7 +110,7 @@ Until then, capture stdout with `os.Pipe()`.
 Use `k8s.io/client-go/kubernetes/fake` to construct a fake clientset that returns
 pre-populated lists without hitting a real cluster.
 
-### pkg/cache (planned, change 0003)
+### pkg/cache
 
 | Test | What to verify |
 |------|---------------|
@@ -129,7 +136,7 @@ skipped in CI unless explicitly enabled.
 
 ## CI/CD and Release Cycle
 
-### Planned CI pipeline (.github/workflows/)
+### Current CI pipeline (.github/workflows/)
 
 #### `ci.yml` — runs on every push and pull request to `master`
 
@@ -140,8 +147,7 @@ jobs:
   build:   go build -o ksearch . (matrix: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64)
 ```
 
-Minimum Go version pinned to whatever `go.mod` declares.
-Use `actions/setup-go` with `cache: true` and `actions/cache` for the vendor directory.
+Minimum Go version is pinned from `go.mod` via `actions/setup-go` with Go module cache enabled.
 
 #### `release.yml` — runs on git tag push matching `v*.*.*`
 
@@ -160,14 +166,13 @@ Artefacts per release:
 - SHA-256 checksums file
 - kubectl krew plugin manifest (`ksearch.yaml`) — required for krew submission
 
-### .goreleaser.yml (to be created)
+### `.goreleaser.yml`
 
 Key settings:
 
 - `builds`: set `ldflags` to inject version string from git tag (`-X main.version={{.Version}}`)
 - `archives`: include `LICENSE` in every archive
 - `checksum`: sha256
-- `release`: auto-generate changelog from commit messages
 - `krew`: generate the krew manifest pointing at the GitHub release assets
 
 ### Release cadence
@@ -184,7 +189,7 @@ Versioning follows **semver**:
 - Minor (`v0.x.0`): new resource kinds, new flags, non-breaking behaviour changes
 - Major (`v1.0.0`): breaking CLI changes (flag renames, output format changes, removed kinds)
 
-### PR checklist (to be added as `.github/pull_request_template.md`)
+### PR checklist
 
 - [ ] `go build ./...` passes
 - [ ] `go vet ./...` passes
@@ -211,6 +216,5 @@ Keep each commit scoped to one logical change. PR descriptions must list:
 
 This tool talks to a live Kubernetes cluster through the current kubeconfig context.
 During development, test against a dedicated non-production namespace.
-The planned application cache (`~/.kube/ksearch/cache/`) stores raw API responses
-including Secret values in plaintext at mode 0600; document this in the README before
-the 0003 change ships.
+The application cache (`~/.kube/ksearch/cache/`) stores command output locally.
+Be careful when validating cache behavior against live clusters.

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -1,0 +1,140 @@
+# Contributing to ksearch
+
+Thanks for evaluating or contributing to `ksearch`.
+
+This document is for contributors. If you want to use the CLI, start with [README.md](/mnt/c/Users/micro/go/src/github.com/arush-sal/ksearch/README.md).
+
+## Project Layout
+
+- `main.go` wires the binary entrypoint to Cobra.
+- `cmd/ksearch.go` owns CLI flags, cache handling, client initialization, discovery, and output flow.
+- `pkg/util/` contains Kubernetes resource discovery and fetch logic.
+- `pkg/printers/` contains formatted stdout rendering.
+- `pkg/cache/` contains local cache read/write logic.
+- `vendor/` stores checked-in dependencies.
+- `openspec/` contains specs and completed change records.
+
+## Local Development
+
+Build the CLI:
+
+```bash
+make build
+```
+
+Run the full test suite:
+
+```bash
+make test
+```
+
+Run vet:
+
+```bash
+make vet
+```
+
+Format Go code:
+
+```bash
+make fmt
+```
+
+Run golangci-lint:
+
+```bash
+make lint
+```
+
+You can also use standard Go commands directly:
+
+```bash
+go test ./...
+go vet ./...
+gofmt -w .
+```
+
+## Development Notes
+
+- Prefer idiomatic Go.
+- Keep CLI wiring in `cmd/`.
+- Keep fetch and discovery logic in `pkg/util/`.
+- Keep output formatting in `pkg/printers/`.
+- Keep cache behavior in `pkg/cache/`.
+- Use `logrus` for recoverable errors in library packages instead of panics.
+
+## Resource Support
+
+`ksearch` discovers resources dynamically from the cluster and fetches them through typed clients where possible, falling back to unstructured handling where needed.
+
+If you add or change printer behavior, verify the output still makes sense for both typed and unstructured resources.
+
+## Testing
+
+Current test coverage includes:
+
+- cache key and cache persistence behavior
+- printer filtering and rendering behavior
+- command-level cache flow
+- discovery and unstructured resource fetching behavior
+
+Run:
+
+```bash
+go test ./...
+```
+
+For a fresh run without cache:
+
+```bash
+go test -count=1 ./...
+```
+
+Integration tests are intended to be run explicitly against a live cluster:
+
+```bash
+go test -tags integration ./...
+```
+
+## CI and Releases
+
+GitHub Actions currently runs:
+
+- lint
+- test with race detection and coverage output
+- multi-platform builds
+
+Tagged releases use GoReleaser and publish archives for Linux, macOS, and Windows. Krew metadata is also generated from the release configuration.
+
+## OpenSpec Workflow
+
+- Active implementation guidance lives under `openspec/changes/`.
+- Completed changes are moved to `openspec/changes/done/`.
+- Specs under `openspec/specs/` describe the intended behavior at a higher level.
+
+If your change maps to an OpenSpec change, keep the related docs aligned.
+
+## Pull Requests
+
+Keep changes scoped and easy to review.
+
+Before opening a PR, verify:
+
+- `make build`
+- `make test`
+- `make vet`
+- any new or changed behavior has test coverage
+- CLI behavior changes are reflected in `README.md`
+
+Prefer short imperative commit subjects such as:
+
+- `Add cache TTL override`
+- `Fix unstructured resource printing`
+- `Improve README installation docs`
+
+## Safety
+
+This tool talks to the current kubeconfig context and may be pointed at a live cluster.
+
+- Test against a non-production namespace when possible.
+- Be careful when validating cache behavior because cached output is stored locally.

--- a/README.md
+++ b/README.md
@@ -1,53 +1,103 @@
-# ksearch
-A kubectl plugin that will help us list all (literally all) the resources in a namespace and the resources can be searched using names as well.
-Right now the resources that are in apps/v1 and core/v1 resouce groups are being printed.
+# 🔎 ksearch
 
-For now we have two main functionalitites in the pugin
+> Search your Kubernetes resources like you mean it.
 
-# List The resources 
-Listing the resources using standard `kubectl get` doesnt give us all the resources that are there in the cluster, for example ingresses and configmaps. Listing the resources using `kubectl search` will list all the resources of a namespace. Example command would be
-```
-kubectl search 
-```
-and it will list all the resources in all the namespaces. To list all the resources from a specific namespace you can use below command
-```
-kubectl search -n <ns-name>
-```
+[![CI](https://img.shields.io/github/actions/workflow/status/arush-sal/ksearch/ci.yml?branch=master&label=CI)](https://github.com/arush-sal/ksearch/actions)
+[![Release](https://img.shields.io/github/v/release/arush-sal/ksearch)](https://github.com/arush-sal/ksearch/releases)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/arush-sal/ksearch)](./go.mod)
+[![License](https://img.shields.io/github/license/arush-sal/ksearch)](./LICENSE)
 
-# Filter the resources 
-Now that we have all the resources from all the namespaces or from a specific namespace, we can filter the resoureces by giving a substring of the resource name, for example the below command 
-```
-kubectl search -name <res-name>
-```
-will list all the resources from all the namespaces if their name contains the string `res-name`. We can provide an options `-n` parameter to do the same in for a specific namespave.
+`ksearch` is a kubectl plugin for cluster-wide resource discovery when `kubectl get` is too narrow. Search by name pattern, limit by kinds, scope by namespace, and reuse cached results for faster repeated lookups. ⚡
 
-# Specify the kinds that you want list
-There are chances that you want some extra resources listed along with the resources that gets listed when we `kubectl get` but not all. `kubectl search` lists a lot of resources that you might not want to see, now you can alos specify the kinds that you want to see along with the basic resources that get displayed when we use `kubectl get`.
-For example to get all the basic resources (that get displayed when we use `kubectl get`) and some extra resources (`configmaps` and `secret`) from `kube-system` namespace we can use 
-```
-kubectl search -n kube-system -kinds configmaps,secret
-```
-We can alwasy use `-name` flag to filter the only resources that match the provided value. For example below command 
-```
-kubectl search -n kube-system -kinds configmap,secret,serviceaccount -name nginx
-```
-will list all the basic resources (that we get from `kubectl get`), configmaps, secrets and serviceaccounts from the `kube-system` namespace that have `nginx` in their name.
+[Install with Krew](#installation) • [Download a release](#installation) • [See examples](#examples)
 
-# Getting Help
-You can run below command to get the list of supported flags.
-```
-kubectl search -h
+## ✨ Features
+
+- 🔍 Search resources by name pattern
+- 📦 Filter results by selected kinds
+- 🧭 Scope to a namespace or search broadly
+- 🧠 Discover supported resources dynamically from the cluster
+- ⚡ Reuse cached output with TTL control
+- 🚀 Install via Krew, GitHub Releases, or source build
+
+## 🚀 Installation
+
+### Krew
+
+```bash
+kubectl krew install ksearch
 ```
 
-# Why ksearch
-There are some situations when you would to know whether the configmaps/secrets that are being referred by the are there in the cluster or not, or the sevice has the respective endpoints created or not. If you use `kubectl get` utility you will have to get the secrets and configmaps separately, but using `ksearch` will list all the resources at once in one place. Similarly lets say you want to get all the resource that are deploys as part of `nginx` deployment, they will most probably have name `nginx` in them. You can just search for all those resources using the below command
-```
-kubectl search -name  <res-name>
-```
-if you know the namespace you can append that using `-n` flag.
+### GitHub Releases
 
-# Installation 
-//TODO, add to kubectl krew plugin repo
+Download the latest archive from:
+`https://github.com/arush-sal/ksearch/releases`
 
-# Demo
-//TODO
+### Build from source
+
+```bash
+git clone https://github.com/arush-sal/ksearch.git
+cd ksearch
+make build
+./ksearch --help
+```
+
+## ⚙️ Quick Start
+
+```bash
+kubectl ksearch
+kubectl ksearch -n kube-system
+kubectl ksearch -n kube-system -p nginx
+```
+
+## 🎯 Examples
+
+Search within one namespace:
+
+```bash
+kubectl ksearch -n default
+```
+
+Find resources related to one workload:
+
+```bash
+kubectl ksearch -n prod -p nginx
+```
+
+Limit output to selected kinds:
+
+```bash
+kubectl ksearch -n prod -k deployment,service,configmap,secret
+```
+
+Skip cache for a fresh read:
+
+```bash
+kubectl ksearch --no-cache
+```
+
+## 🛠 Flags
+
+| Flag | Description |
+|---|---|
+| `-n, --namespace` | Namespace to search |
+| `-p, --pattern` | Match resource names by substring |
+| `-k, --kinds` | Comma-separated kinds or resources to include |
+| `--cache-ttl` | Cache TTL, defaults to `1m` |
+| `--no-cache` | Skip cached output |
+
+Environment override:
+
+```bash
+export KSEARCH_CACHE_TTL=30s
+```
+
+## 📝 Notes
+
+- Resource discovery depends on what the current cluster exposes.
+- Cached output is stored locally and reused until the TTL expires.
+- Use `--no-cache` when you need a fully fresh read.
+
+## 🤝 Contributing
+
+Contributor-facing documentation lives in `CONTRIBUTION.md`.


### PR DESCRIPTION
## Summary
- refresh the user-facing README to match the current CLI status and distribution paths
- add CONTRIBUTION.md for contributor setup, testing, and release guidance
- update AGENTS.md so repo instructions reflect the current Makefile, tests, CI, and cache behavior

## Test Plan
- documentation-only change
- verification was performed locally by the user