### PR TITLE
feat: prepare official Krew index submission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,22 @@ jobs:
           name: ksearch-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist/ksearch-${{ matrix.goos }}-${{ matrix.goarch }}*
           if-no-files-found: error
+
+  krew-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: azure/setup-kubectl@v4
+        with:
+          version: latest
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          install-only: true
+      - name: Validate Krew install flow
+        run: bash scripts/validate-krew-install.sh

--- a/.github/workflows/krew-release.yml
+++ b/.github/workflows/krew-release.yml
@@ -1,0 +1,16 @@
+name: Update krew-index
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  krew-update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: rajatjindal/krew-release-bot@v0.0.46

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,8 +36,17 @@ krews:
     ids:
       - default
     homepage: https://github.com/arush-sal/ksearch
-    short_description: Search and list all Kubernetes resources in a namespace
-    description: Search and list all Kubernetes resources in a namespace.
+    short_description: Search Kubernetes resources across API groups
+    description: |
+      ksearch lists and searches Kubernetes resources across both core/v1 and
+      apps/v1 API groups, including resources that kubectl get omits by
+      default. It supports substring matching, namespace scoping, kind
+      filtering, dynamic discovery, and cached output for repeated queries.
+    caveats: |
+      Requires a valid kubeconfig context and uses the current context by
+      default. Results are cached for 60s unless --cache-ttl or --no-cache is
+      used.
+    skip_upload: true
     repository:
       owner: arush-sal
       name: krew-index

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,48 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: ksearch
+spec:
+  version: {{ .TagName }}
+  homepage: https://github.com/arush-sal/ksearch
+  shortDescription: Search Kubernetes resources across API groups
+  description: |
+    ksearch lists and searches Kubernetes resources across both core/v1 and
+    apps/v1 API groups, including resources that kubectl get omits by default.
+    It supports substring matching, namespace scoping, kind filtering, dynamic
+    discovery, and cached output for repeated queries.
+  caveats: |
+    Requires a valid kubeconfig context and uses the current context by
+    default. Results are cached for 60s unless --cache-ttl or --no-cache is
+    used.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      {{addURIAndSha "https://github.com/arush-sal/ksearch/releases/download/{{ .TagName }}/ksearch_linux_amd64.tar.gz" .TagName }}
+      bin: ksearch
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      {{addURIAndSha "https://github.com/arush-sal/ksearch/releases/download/{{ .TagName }}/ksearch_linux_arm64.tar.gz" .TagName }}
+      bin: ksearch
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      {{addURIAndSha "https://github.com/arush-sal/ksearch/releases/download/{{ .TagName }}/ksearch_darwin_amd64.tar.gz" .TagName }}
+      bin: ksearch
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      {{addURIAndSha "https://github.com/arush-sal/ksearch/releases/download/{{ .TagName }}/ksearch_darwin_arm64.tar.gz" .TagName }}
+      bin: ksearch
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      {{addURIAndSha "https://github.com/arush-sal/ksearch/releases/download/{{ .TagName }}/ksearch_windows_amd64.zip" .TagName }}
+      bin: ksearch.exe

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 
 ### Krew
 
+After the plugin is accepted into the official `kubernetes-sigs/krew-index`:
+
 ```bash
 kubectl krew install ksearch
 ```

--- a/cmd/ksearch.go
+++ b/cmd/ksearch.go
@@ -9,6 +9,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -43,7 +44,6 @@ var (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:     "ksearch",
 	Short:   "run ksearch --help to get the usage",
 	Version: version,
 	Long:    `ksearch is a command line tool to search for a given pattern in a Kubernetes cluster and will print all of the available resources in a cluster if none is provided`,
@@ -152,6 +152,7 @@ func SetVersion(buildVersion string) {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+	rootCmd.Use = pluginName()
 	rootCmd.PersistentFlags().StringVarP(&resName, "pattern", "p", "", "pattern you want to search for")
 	rootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "namespace you want to search in")
 	rootCmd.PersistentFlags().StringVarP(&kinds, "kinds", "k", "", "comma separated list of all the kinds that you want to include")
@@ -161,6 +162,20 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
+}
+
+func pluginName() string {
+	base := os.Args[0]
+	if lastSeparator := strings.LastIndexAny(base, `/\`); lastSeparator >= 0 {
+		base = base[lastSeparator+1:]
+	}
+
+	base = strings.TrimSuffix(base, ".exe")
+	if strings.HasPrefix(base, "kubectl-") {
+		return "kubectl " + strings.TrimPrefix(base, "kubectl-")
+	}
+
+	return base
 }
 
 func resolvedCacheTTL(cmd *cobra.Command) (time.Duration, error) {

--- a/cmd/ksearch_test.go
+++ b/cmd/ksearch_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -13,6 +14,45 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
+
+func TestPluginName_WithKubectlPrefix(t *testing.T) {
+	originalArgs := os.Args
+	t.Cleanup(func() {
+		os.Args = originalArgs
+	})
+
+	os.Args = []string{"/usr/local/bin/kubectl-ksearch"}
+
+	if got := pluginName(); got != "kubectl ksearch" {
+		t.Fatalf("expected kubectl plugin name, got %q", got)
+	}
+}
+
+func TestPluginName_WithoutPrefix(t *testing.T) {
+	originalArgs := os.Args
+	t.Cleanup(func() {
+		os.Args = originalArgs
+	})
+
+	os.Args = []string{"/usr/local/bin/ksearch"}
+
+	if got := pluginName(); got != "ksearch" {
+		t.Fatalf("expected standalone binary name, got %q", got)
+	}
+}
+
+func TestPluginName_WindowsExe(t *testing.T) {
+	originalArgs := os.Args
+	t.Cleanup(func() {
+		os.Args = originalArgs
+	})
+
+	os.Args = []string{`C:\Users\foo\kubectl-ksearch.exe`}
+
+	if got := pluginName(); got != "kubectl ksearch" {
+		t.Fatalf("expected kubectl plugin name for windows path, got %q", got)
+	}
+}
 
 func TestRunUsesCacheBeforeDiscovery(t *testing.T) {
 	t.Cleanup(func() {

--- a/openspec/changes/0007-krew-plugin-listing/design.md
+++ b/openspec/changes/0007-krew-plugin-listing/design.md
@@ -83,6 +83,7 @@ krews:
     caveats: |
       Requires a valid kubeconfig context. Uses the current-context by default.
       Results are cached for 60s; use --no-cache to bypass.
+    skip_upload: true
     repository:
       owner: arush-sal
       name: krew-index
@@ -91,10 +92,31 @@ krews:
 **Note on target index:** GoReleaser's `krews` section publishes to the repo
 specified in `repository`. For the official `kubernetes-sigs/krew-index`, the
 initial PR is manual (fork + PR to the official repo). After acceptance,
-`krew-release-bot` handles updates. The GoReleaser krew config generates
-the manifest template that the bot uses.
+`krew-release-bot` handles updates. `skip_upload: true` keeps GoReleaser focused
+on generating the local validation manifest in `dist/krew/ksearch.yaml` without
+trying to push to a personal krew-index repository from CI.
 
-## 4. krew-release-bot GitHub Action
+## 4. krew-release-bot GitHub Action and template
+
+Add a root `.krew.yaml` template for the bot to render on each release:
+
+```yaml
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: ksearch
+spec:
+  version: {{ .TagName }}
+  homepage: https://github.com/arush-sal/ksearch
+  shortDescription: Search Kubernetes resources across API groups
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      {{addURIAndSha "https://github.com/arush-sal/ksearch/releases/download/{{ .TagName }}/ksearch_linux_amd64.tar.gz" .TagName }}
+      bin: ksearch
+```
 
 Add `.github/workflows/krew-release.yml`:
 
@@ -109,12 +131,13 @@ jobs:
   krew-update:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: rajatjindal/krew-release-bot@v0.0.46
 ```
 
 This action:
 - Triggers when a GitHub Release is published (which GoReleaser does on tag push)
-- Reads the `.goreleaser.yml` krew config to build the manifest
+- Reads `.krew.yaml` to build the manifest for the official index update PR
 - Opens a PR to `kubernetes-sigs/krew-index` automatically
 - Trivial version bumps (only version, uri, sha256 changed) are auto-merged
 
@@ -167,6 +190,7 @@ After the first tagged release with the updated GoReleaser config:
 | File | Action |
 |------|--------|
 | `.goreleaser.yml` | **Update** — krew descriptions, caveats (binary name unchanged) |
+| `.krew.yaml` | **New** — template consumed by `krew-release-bot` |
 | `cmd/ksearch.go` | **Update** — add `pluginName()`, set `rootCmd.Use` dynamically |
 | `.github/workflows/krew-release.yml` | **New** — krew-release-bot action |
 

--- a/openspec/changes/0007-krew-plugin-listing/design.md
+++ b/openspec/changes/0007-krew-plugin-listing/design.md
@@ -154,20 +154,43 @@ goreleaser release --snapshot --clean
 # 2. Find the generated manifest
 cat dist/krew/ksearch.yaml
 
-# 3. Test installation with the local archive
-kubectl krew install --manifest=dist/krew/ksearch.yaml \
-  --archive=dist/ksearch_linux_amd64.tar.gz
+# 3. Create a local linux/amd64 test archive from the built binary
+mkdir -p /tmp/ksearch-local-archive
+cp dist/ksearch_linux_amd64_v1/ksearch /tmp/ksearch-local-archive/ksearch
+cp LICENSE /tmp/ksearch-local-archive/LICENSE
+tar -C /tmp/ksearch-local-archive -czf /tmp/ksearch_local_linux_amd64.tar.gz \
+  ksearch LICENSE
 
-# 4. Verify
+# 4. Update the linux/amd64 sha256 in dist/krew/ksearch.yaml to match the
+#    local test archive. Krew still validates the manifest checksum even when
+#    --archive overrides the download URI.
+sha256sum /tmp/ksearch_local_linux_amd64.tar.gz
+
+# 5. Test installation with the local archive
+kubectl krew install --manifest=dist/krew/ksearch.yaml \
+  --archive=/tmp/ksearch_local_linux_amd64.tar.gz
+
+# 6. Verify
 kubectl ksearch --help
 kubectl ksearch -n default
 
-# 5. Cross-platform validation (simulate darwin/arm64 on linux)
+# 7. Cleanup
+kubectl krew uninstall ksearch
+```
+
+For local install tests, the manifest checksum must match the custom archive.
+`--archive` replaces the download source, but Krew still verifies the selected
+platform entry's `sha256` from the manifest before unpacking.
+
+Cross-platform validation can still use the generated release archives directly:
+
+```bash
+# 8. Cross-platform validation (simulate darwin/arm64 on linux)
 KREW_OS=darwin KREW_ARCH=arm64 kubectl krew install \
   --manifest=dist/krew/ksearch.yaml \
   --archive=dist/ksearch_darwin_arm64.tar.gz
 
-# 6. Cleanup
+# 9. Cleanup
 kubectl krew uninstall ksearch
 ```
 

--- a/openspec/changes/0007-krew-plugin-listing/proposal.md
+++ b/openspec/changes/0007-krew-plugin-listing/proposal.md
@@ -8,8 +8,10 @@ ksearch is a kubectl plugin, but it cannot be discovered or installed via
 not the official `kubernetes-sigs/krew-index`. Additionally, several gaps
 prevent a clean krew experience:
 
-1. **Binary name**: built as `ksearch`, not `kubectl-ksearch`. Without krew,
-   placing the binary on PATH does not register it as a kubectl plugin.
+1. **Binary packaging contract**: the revised design keeps the built binary as
+   `ksearch`, but parts of the spec still incorrectly require `kubectl-ksearch`.
+   The packaging docs and manifests need to be reconciled around krew's symlink
+   behavior.
 2. **No automated krew-index updates**: each new release requires a manual PR
    to whichever krew-index repo is used.
 3. **Help text is not kubectl-aware**: `ksearch --help` shows `ksearch` as the
@@ -23,19 +25,22 @@ prevent a clean krew experience:
 
 Make ksearch a first-class krew plugin:
 
-1. Rename the built binary to `kubectl-ksearch` (works both with and without krew).
-2. Detect invocation context (`kubectl ksearch` vs `kubectl-ksearch`) and adjust
+1. Keep the built binary as `ksearch`; rely on the krew manifest `bin` field and
+   the symlink krew creates for `kubectl ksearch`.
+2. Detect invocation context (`kubectl ksearch` vs direct `ksearch`) and adjust
    help output accordingly.
 3. Add `krew-release-bot` GitHub Action to automate krew-index PRs on tag push.
 4. Refine `.goreleaser.yml` krew config (caveats, description, target the official index).
-5. Document local krew validation in the openspec tasks.
-6. Submit the initial manifest PR to `kubernetes-sigs/krew-index`.
+5. Add a `.krew.yaml` template for `krew-release-bot`, while keeping GoReleaser
+   as the source for local manifest validation.
+6. Document local krew validation in the openspec tasks.
+7. Submit the initial manifest PR to `kubernetes-sigs/krew-index`.
 
 ## Benefits
 
 - Users discover and install via `kubectl krew install ksearch`
 - Auto-updated on every tagged release (no manual krew-index PRs)
-- Works without krew too: `kubectl-ksearch` on PATH is auto-discovered by kubectl
+- Works with krew without changing the standalone `ksearch` binary name
 - Broader adoption through the official plugin index
 
 ## Risks and mitigations
@@ -43,5 +48,5 @@ Make ksearch a first-class krew plugin:
 | Risk | Mitigation |
 |------|-----------|
 | krew-index PR rejected on naming or quality | Follow naming guide strictly; test locally first |
-| Binary rename breaks existing users | `ksearch` binary name was never published via krew; no backward compat concern |
+| Stale specs/docs keep referring to `kubectl-ksearch` | Update proposal, task list, and distribution spec to match the revised design |
 | krew-release-bot misconfigured | Test with `--snapshot` before first real tag |

--- a/openspec/changes/0007-krew-plugin-listing/specs/distribution.delta.md
+++ b/openspec/changes/0007-krew-plugin-listing/specs/distribution.delta.md
@@ -5,13 +5,14 @@ Applies to: `openspec/specs/distribution/spec.md` (new capability spec)
 ## New requirements
 
 ### Requirement: kubectl plugin discovery
-The binary SHALL be named `kubectl-ksearch` so that kubectl's plugin discovery
-mechanism registers it as `kubectl ksearch` without requiring krew.
+The distributed binary SHALL remain named `ksearch`. The krew manifest SHALL
+identify `ksearch` (or `ksearch.exe` on Windows) as the installed executable,
+and krew SHALL provide the `kubectl-ksearch` symlink used for plugin discovery.
 
 #### Scenario: Plugin discovered by kubectl
-- GIVEN the `kubectl-ksearch` binary is on PATH
+- GIVEN the plugin is installed by krew
 - WHEN `kubectl plugin list` is run
-- THEN `kubectl-ksearch` appears in the list
+- THEN `kubectl-ksearch` appears in the list via the symlink krew created
 
 ### Requirement: Krew index listing
 The plugin SHALL be listed on the official `kubernetes-sigs/krew-index` so
@@ -42,9 +43,9 @@ and show the bare binary name otherwise.
 - THEN the usage line reads `kubectl ksearch [flags]`
 
 #### Scenario: Help text via direct invocation
-- GIVEN the binary is invoked directly as `./kubectl-ksearch`
+- GIVEN the binary is invoked directly as `./ksearch`
 - WHEN `--help` is passed
-- THEN the usage line reads `kubectl ksearch [flags]`
+- THEN the usage line reads `ksearch [flags]`
 
 ### Requirement: Cross-platform archives
 Release archives SHALL be produced for linux/amd64, linux/arm64, darwin/amd64,
@@ -53,4 +54,4 @@ darwin/arm64, and windows/amd64. Each SHALL include the binary and a LICENSE fil
 #### Scenario: Archive contents
 - GIVEN a release archive for linux/amd64
 - WHEN extracted
-- THEN it contains `kubectl-ksearch` and `LICENSE`
+- THEN it contains `ksearch` and `LICENSE`

--- a/openspec/changes/0007-krew-plugin-listing/tasks.md
+++ b/openspec/changes/0007-krew-plugin-listing/tasks.md
@@ -35,6 +35,10 @@ The `pluginName()` function detects the invocation context at runtime.
 
 ## Phase 3 — krew-release-bot GitHub Action
 
+- [ ] Create `.krew.yaml` with platform entries for linux/amd64, linux/arm64,
+  darwin/amd64, darwin/arm64, and windows/amd64 using `bin: ksearch`
+  (`ksearch.exe` on Windows) and release asset URLs under
+  `https://github.com/arush-sal/ksearch/releases/download/{{ .TagName }}/...`
 - [ ] Create `.github/workflows/krew-release.yml`:
   ```yaml
   name: Update krew-index
@@ -47,6 +51,7 @@ The `pluginName()` function detects the invocation context at runtime.
     krew-update:
       runs-on: ubuntu-latest
       steps:
+        - uses: actions/checkout@v4
         - uses: rajatjindal/krew-release-bot@v0.0.46
   ```
 - [ ] Verify: the existing `release.yml` triggers on `push: tags: ['v*.*.*']` which
@@ -59,7 +64,7 @@ The `pluginName()` function detects the invocation context at runtime.
   - Verify `apiVersion: krew.googlecontainertools.github.com/v1alpha2`
   - Verify `metadata.name: ksearch`
   - Verify all platform entries have `uri`, `sha256`, `bin`
-  - Verify `bin: kubectl-ksearch` (non-windows) and `bin: kubectl-ksearch.exe` (windows)
+  - Verify `bin: ksearch` (non-windows) and `bin: ksearch.exe` (windows)
 - [ ] Test local install (requires krew installed):
   ```bash
   kubectl krew install --manifest=dist/krew/ksearch.yaml \

--- a/openspec/changes/0007-krew-plugin-listing/tasks.md
+++ b/openspec/changes/0007-krew-plugin-listing/tasks.md
@@ -65,10 +65,15 @@ The `pluginName()` function detects the invocation context at runtime.
   - Verify `metadata.name: ksearch`
   - Verify all platform entries have `uri`, `sha256`, `bin`
   - Verify `bin: ksearch` (non-windows) and `bin: ksearch.exe` (windows)
+- [ ] Create a local linux/amd64 validation archive from `dist/ksearch_linux_amd64_v1/ksearch`
+  plus `LICENSE`, packaged as a `.tar.gz`
+- [ ] Update the linux/amd64 `sha256` in `dist/krew/ksearch.yaml` to match the
+  local validation archive. `kubectl krew install --archive=...` still validates
+  the platform checksum from the manifest.
 - [ ] Test local install (requires krew installed):
   ```bash
   kubectl krew install --manifest=dist/krew/ksearch.yaml \
-    --archive=dist/ksearch_linux_amd64.tar.gz
+    --archive=/tmp/ksearch_local_linux_amd64.tar.gz
   kubectl ksearch --help
   kubectl ksearch --version
   kubectl krew uninstall ksearch
@@ -112,7 +117,8 @@ The `pluginName()` function detects the invocation context at runtime.
 - [ ] `./ksearch --version` — prints injected version
 - [ ] `goreleaser release --snapshot --clean` — succeeds, manifest generated
 - [ ] `cat dist/krew/ksearch.yaml` — `bin: ksearch` (not `kubectl-ksearch`)
-- [ ] `kubectl krew install --manifest=dist/krew/ksearch.yaml --archive=dist/ksearch_linux_amd64.tar.gz` — installs cleanly
+- [ ] local linux/amd64 test archive checksum is copied into `dist/krew/ksearch.yaml`
+- [ ] `kubectl krew install --manifest=dist/krew/ksearch.yaml --archive=/tmp/ksearch_local_linux_amd64.tar.gz` — installs cleanly
 - [ ] `kubectl ksearch --help` — shows `kubectl ksearch` (krew symlink detected)
 - [ ] `kubectl ksearch -n kube-system` — produces output
 - [ ] `kubectl krew uninstall ksearch` — removes cleanly

--- a/openspec/specs/distribution/spec.md
+++ b/openspec/specs/distribution/spec.md
@@ -7,13 +7,14 @@ kubectl plugin — both via the krew plugin index and via manual installation.
 ## Requirements
 
 ### Requirement: kubectl plugin discovery
-The binary SHALL be named `kubectl-ksearch` so that kubectl's plugin discovery
-mechanism registers it as `kubectl ksearch` without requiring krew.
+The distributed binary SHALL remain named `ksearch`. The krew manifest SHALL
+identify `ksearch` (or `ksearch.exe` on Windows) as the installed executable,
+and krew SHALL provide the `kubectl-ksearch` symlink used for plugin discovery.
 
 #### Scenario: Plugin discovered by kubectl
-- GIVEN the `kubectl-ksearch` binary is on PATH
+- GIVEN the plugin is installed by krew
 - WHEN `kubectl plugin list` is run
-- THEN `kubectl-ksearch` appears in the list
+- THEN `kubectl-ksearch` appears in the list via the symlink krew created
 
 ### Requirement: Krew index listing
 The plugin SHALL be listed on the official `kubernetes-sigs/krew-index` so
@@ -43,6 +44,11 @@ plugin and show the bare binary name otherwise.
 - WHEN `--help` is passed
 - THEN the usage line reads `kubectl ksearch [flags]`
 
+#### Scenario: Help text via direct invocation
+- GIVEN the binary is invoked directly as `./ksearch`
+- WHEN `--help` is passed
+- THEN the usage line reads `ksearch [flags]`
+
 ### Requirement: Cross-platform archives
 Release archives SHALL be produced for linux/amd64, linux/arm64, darwin/amd64,
 darwin/arm64, and windows/amd64. Each SHALL include the binary and a LICENSE file.
@@ -50,4 +56,4 @@ darwin/arm64, and windows/amd64. Each SHALL include the binary and a LICENSE fil
 #### Scenario: Archive contents
 - GIVEN a release archive for linux/amd64
 - WHEN extracted
-- THEN it contains `kubectl-ksearch` and `LICENSE`
+- THEN it contains `ksearch` and `LICENSE`

--- a/scripts/validate-krew-install.sh
+++ b/scripts/validate-krew-install.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cleanup() {
+	kubectl krew uninstall ksearch >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+install_krew() {
+	if kubectl krew version >/dev/null 2>&1; then
+		return
+	fi
+
+	local temp_dir os arch krew
+	temp_dir="$(mktemp -d)"
+	os="$(uname | tr '[:upper:]' '[:lower:]')"
+	arch="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
+	krew="krew-${os}_${arch}"
+
+	curl -fsSL "https://github.com/kubernetes-sigs/krew/releases/latest/download/${krew}.tar.gz" -o "${temp_dir}/${krew}.tar.gz"
+	tar -C "${temp_dir}" -zxf "${temp_dir}/${krew}.tar.gz"
+	"${temp_dir}/${krew}" install krew
+	rm -rf "${temp_dir}"
+}
+
+main() {
+	export KREW_ROOT="${KREW_ROOT:-${HOME}/.krew}"
+	export PATH="${KREW_ROOT}/bin:${PATH}"
+
+	install_krew
+
+	rm -rf dist
+	goreleaser release --snapshot --clean
+
+	local manifest archive plugin_path help_output
+	manifest="dist/krew/ksearch.yaml"
+	archive="dist/ksearch_linux_amd64.tar.gz"
+
+	if [[ ! -f "${manifest}" ]]; then
+		echo "missing manifest: ${manifest}" >&2
+		exit 1
+	fi
+
+	if [[ ! -f "${archive}" ]]; then
+		echo "missing archive: ${archive}" >&2
+		exit 1
+	fi
+
+	kubectl krew uninstall ksearch >/dev/null 2>&1 || true
+	kubectl krew install --manifest="${manifest}" --archive="${archive}"
+
+	plugin_path="$(command -v kubectl-ksearch)"
+	if [[ -z "${plugin_path}" ]]; then
+		echo "kubectl-ksearch not found on PATH after install" >&2
+		exit 1
+	fi
+
+	if ! kubectl plugin list | grep -q 'kubectl-ksearch'; then
+		echo "kubectl plugin list did not include kubectl-ksearch" >&2
+		exit 1
+	fi
+
+	help_output="$(kubectl ksearch --help)"
+	if [[ "${help_output}" != *"kubectl ksearch [flags]"* ]]; then
+		echo "unexpected help output:" >&2
+		printf '%s\n' "${help_output}" >&2
+		exit 1
+	fi
+
+	printf 'Validated Krew install via %s\n' "${archive}"
+	printf 'Plugin command path: %s\n' "${plugin_path}"
+	printf '%s\n' "${help_output}" | sed -n '1,10p'
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- prepare the release metadata and automation needed for official `kubernetes-sigs/krew-index` submission
- keep the shipped binary name as `ksearch`, add runtime kubectl-aware help text, and add regression tests for Unix and Windows invocation paths
- add `.krew.yaml` plus a `krew-release-bot` workflow, and align the `0007` openspec docs/specs with the revised binary-name decision
- document the tested local Krew validation flow, including the manifest checksum requirement when using `--archive`
- add a CI Krew validation job that installs Krew, builds a GoReleaser snapshot, installs the plugin from the generated manifest and archive, and verifies `kubectl ksearch --help`

## Why

The `0007-krew-plugin-listing` change requires the repo to be ready for the initial official Krew index submission and for automated update PRs after release. The existing GoReleaser config was still aimed at a personal krew index and the spec bundle still had stale `kubectl-ksearch` assumptions.

## Verification

- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `go build -o ksearch .`
- `./ksearch --help`
- `cp ksearch kubectl-ksearch && ./kubectl-ksearch --help`
- `goreleaser release --snapshot --clean`
- inspected `dist/krew/ksearch.yaml` and confirmed `bin: ksearch` on non-Windows targets and `bin: ksearch.exe` on Windows
- created a linux/amd64 tarball from `dist/ksearch_linux_amd64_v1/ksearch` plus `LICENSE`
- updated the linux/amd64 `sha256` in `dist/krew/ksearch.yaml` to match the local archive because Krew still validates manifest checksums when `--archive` is used
- `kubectl krew install --manifest=dist/krew/ksearch.yaml --archive=<local-linux-amd64-tar.gz>`
- `kubectl plugin list | rg 'ksearch'`
- `command -v kubectl-ksearch`
- `kubectl ksearch --help`
- `kubectl krew uninstall ksearch`
- `bash scripts/validate-krew-install.sh`

## Notes

- The local Krew install test succeeded after aligning the manifest checksum with the custom local archive.
- The CI job validates the simpler generated-archive path directly with `dist/ksearch_linux_amd64.tar.gz`, which already matches the GoReleaser-generated manifest checksum.
- GitHub issue auto-closing was not configured here because there is no open GitHub issue matching `0007-krew-plugin-listing` in this repo.
